### PR TITLE
feat(auth, exam): move access token to HttpOnly cookie and add exam aggregate counts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,49 @@
+name: CD Pipeline
+
+on:
+  workflow_run:
+    workflows: [ "CI Pipeline" ]
+    branches: [ main ]
+    types: [ completed ]
+
+jobs:
+  deploy:
+    name: Deploy to On-Premises
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Copy docker-compose.prod.yml to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          source: docker-compose.prod.yml
+          target: /opt/vibecode/
+
+      - name: Pull latest image & restart containers
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          script: |
+            set -e
+            cd /opt/vibecode
+
+            echo ">>> Pulling latest app image..."
+            docker compose -f docker-compose.prod.yml pull app
+
+            echo ">>> Restarting containers..."
+            docker compose -f docker-compose.prod.yml up -d --remove-orphans
+
+            echo ">>> Pruning old images..."
+            docker image prune -f
+
+            echo ">>> Deploy complete. Container status:"
+            docker compose -f docker-compose.prod.yml ps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: Build & Push Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -22,18 +23,56 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
+      # application-secret.yml은 .gitignore에 포함되어 있으므로 CI에서 생성
+      # ${VAR:secret_value} 형식: 런타임 env가 있으면 env 우선, 없으면 시크릿 값 사용
+      - name: Create application-secret.yml from GitHub Secrets
+        run: |
+          cat > src/main/resources/application-secret.yml << 'EOF'
+          spring:
+            datasource:
+              url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5435}/${DB_NAME:ai_vibe_coding_test}
+              username: ${DB_USERNAME:${{ secrets.DB_USERNAME }}}
+              password: ${DB_PASSWORD:${{ secrets.DB_PASSWORD }}}
+              driver-class-name: org.postgresql.Driver
+
+            jpa:
+              hibernate:
+                ddl-auto: ${JPA_DDL_AUTO:update}
+              properties:
+                hibernate:
+                  dialect: org.hibernate.dialect.PostgreSQLDialect
+                  format_sql: true
+                  default_schema: ${DB_SCHEMA:ai_vibe_coding_test}
+              show-sql: false
+
+          jwt:
+            key: ${JWT_KEY:${{ secrets.JWT_KEY }}}
+            access:
+              expiration: ${JWT_ACCESS_EXPIRATION:3600000}
+            refresh:
+              expiration: ${JWT_REFRESH_EXPIRATION:86400000}
+
+          master:
+            admin:
+              admin-number: ${MASTER_ADMIN_NUMBER:${{ secrets.MASTER_ADMIN_NUMBER }}}
+              email: ${MASTER_ADMIN_EMAIL:${{ secrets.MASTER_ADMIN_EMAIL }}}
+              password: ${MASTER_ADMIN_PASSWORD:${{ secrets.MASTER_ADMIN_PASSWORD }}}
+
+          ai:
+            server:
+              url: ${AI_SERVER_URL:${{ secrets.AI_SERVER_URL }}}
+          EOF
+
+      - name: Build with Gradle (tests included)
         run: ./gradlew clean build
 
       - name: Log in to Docker Hub
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build & Push Docker Image
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.gradle-local/
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
@@ -113,3 +114,4 @@ buildNumber.properties
 /docs/
 
 .claude/
+.env

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,96 @@
+# 온프레미스 프로덕션 배포용 Docker Compose
+# 서버의 /opt/vibecode/.env 파일에서 환경변수를 읽습니다.
+# 사용법: docker compose -f docker-compose.prod.yml up -d
+
+services:
+
+  # ─── BE 애플리케이션 ──────────────────────────────────────────────────
+  app:
+    image: ${DOCKERHUB_USERNAME}/vibecode:latest
+    container_name: vibecode-app
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    environment:
+      # Database (postgres 서비스명을 호스트로 사용)
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_NAME: ai_vibe_coding_test
+      DB_SCHEMA: ai_vibe_coding_test
+      DB_USERNAME: ${DB_USERNAME}
+      DB_PASSWORD: ${DB_PASSWORD}
+      JPA_DDL_AUTO: update
+      # JWT
+      JWT_KEY: ${JWT_KEY}
+      JWT_ACCESS_EXPIRATION: ${JWT_ACCESS_EXPIRATION:-3600000}
+      JWT_REFRESH_EXPIRATION: ${JWT_REFRESH_EXPIRATION:-86400000}
+      # Redis (redis 서비스명을 호스트로 사용)
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      # CORS / Cookie
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
+      COOKIE_SECURE: "true"
+      # Master Admin
+      MASTER_ADMIN_NUMBER: ${MASTER_ADMIN_NUMBER}
+      MASTER_ADMIN_EMAIL: ${MASTER_ADMIN_EMAIL}
+      MASTER_ADMIN_PASSWORD: ${MASTER_ADMIN_PASSWORD}
+      # AI Server — 호스트에서 실행 중인 AI 서버 접근 (Linux host-gateway)
+      AI_SERVER_URL: ${AI_SERVER_URL:-http://host.docker.internal:8000}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"  # Linux에서 host.docker.internal 활성화
+    networks:
+      - vibecode-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/actuator/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # ─── PostgreSQL ───────────────────────────────────────────────────────
+  postgres:
+    image: postgres:15-alpine
+    container_name: vibecode_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ai_vibe_coding_test
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - vibecode-net
+
+  # ─── Redis ────────────────────────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    container_name: vibecode-redis
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+    command: redis-server --appendonly yes
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+    networks:
+      - vibecode-net
+
+volumes:
+  postgres_data:
+  redis-data:
+
+networks:
+  vibecode-net:
+    driver: bridge

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamsUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamsUseCase.java
@@ -8,7 +8,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.yd.vibecode.domain.exam.application.dto.response.ExamResponse;
 import com.yd.vibecode.domain.exam.domain.entity.Exam;
+import com.yd.vibecode.domain.exam.domain.repository.ExamParticipantRepository;
 import com.yd.vibecode.domain.exam.domain.repository.ExamRepository;
+import com.yd.vibecode.domain.submission.domain.repository.SubmissionRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,12 +20,18 @@ import lombok.RequiredArgsConstructor;
 public class GetExamsUseCase {
 
     private final ExamRepository examRepository;
+    private final ExamParticipantRepository examParticipantRepository;
+    private final SubmissionRepository submissionRepository;
 
     public List<ExamResponse> execute() {
         List<Exam> exams = examRepository.findAll();
         
         return exams.stream()
-            .map(ExamResponse::from)
+            .map(exam -> ExamResponse.from(
+                exam,
+                examParticipantRepository.countByExamId(exam.getId()),
+                submissionRepository.countByExamId(exam.getId())
+            ))
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamsUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamsUseCase.java
@@ -1,6 +1,7 @@
 package com.yd.vibecode.domain.admin.application.usecase;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -25,13 +26,27 @@ public class GetExamsUseCase {
 
     public List<ExamResponse> execute() {
         List<Exam> exams = examRepository.findAll();
-        
+        if (exams.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> examIds = exams.stream().map(Exam::getId).collect(Collectors.toList());
+
+        // Bulk GROUP BY queries: 2 queries total instead of 2N
+        Map<Long, Long> participantCounts = examParticipantRepository.countGroupByExamIdIn(examIds)
+                .stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
+
+        Map<Long, Long> completedCounts = submissionRepository.countGroupByExamIdIn(examIds)
+                .stream()
+                .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
+
         return exams.stream()
-            .map(exam -> ExamResponse.from(
-                exam,
-                examParticipantRepository.countByExamId(exam.getId()),
-                submissionRepository.countByExamId(exam.getId())
-            ))
-            .collect(Collectors.toList());
+                .map(exam -> ExamResponse.from(
+                        exam,
+                        participantCounts.getOrDefault(exam.getId(), 0L),
+                        completedCounts.getOrDefault(exam.getId(), 0L)
+                ))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/auth/ui/AuthController.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/ui/AuthController.java
@@ -45,6 +45,9 @@ public class AuthController implements AuthApi {
         EnterResponse response = enterUseCase.execute(request);
         int maxAge = Math.toIntExact(jwtProperties.getAccessTokenExpirationPeriodDay() / 1000);
         cookieUtils.setAccessTokenCookie(httpResponse, response.accessToken(), maxAge);
+        // accessToken is intentionally kept in the response body so the FE can store it
+        // in Zustand memory for STOMP WebSocket authentication (HttpOnly cookies are
+        // not readable by JavaScript and therefore cannot be used in STOMP connectHeaders).
         return BaseResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/yd/vibecode/domain/auth/ui/AuthController.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/ui/AuthController.java
@@ -14,6 +14,9 @@ import com.yd.vibecode.domain.auth.application.usecase.MeUseCase;
 import com.yd.vibecode.global.annotation.AccessToken;
 import com.yd.vibecode.global.swagger.AuthApi;
 import com.yd.vibecode.global.common.BaseResponse;
+import com.yd.vibecode.global.security.JwtProperties;
+import com.yd.vibecode.global.util.CookieUtils;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,10 +35,16 @@ public class AuthController implements AuthApi {
     private final AdminLoginUseCase adminLoginUseCase;
     private final AdminLogoutUseCase adminLogoutUseCase;
     private final MeUseCase meUseCase;
+    private final CookieUtils cookieUtils;
+    private final JwtProperties jwtProperties;
 
     @PostMapping("/enter")
-    public BaseResponse<EnterResponse> enter(@Valid @RequestBody EnterRequest request) {
+    public BaseResponse<EnterResponse> enter(
+            @Valid @RequestBody EnterRequest request,
+            HttpServletResponse httpResponse) {
         EnterResponse response = enterUseCase.execute(request);
+        int maxAge = Math.toIntExact(jwtProperties.getAccessTokenExpirationPeriodDay() / 1000);
+        cookieUtils.setAccessTokenCookie(httpResponse, response.accessToken(), maxAge);
         return BaseResponse.onSuccess(response);
     }
 
@@ -46,15 +55,21 @@ public class AuthController implements AuthApi {
     }
 
     @PostMapping("/admin/login")
-    public BaseResponse<AdminLoginResponse> adminLogin(@Valid @RequestBody AdminLoginRequest request) {
+    public BaseResponse<AdminLoginResponse> adminLogin(
+            @Valid @RequestBody AdminLoginRequest request,
+            HttpServletResponse httpResponse) {
         AdminLoginResponse response = adminLoginUseCase.execute(request);
+        int maxAge = Math.toIntExact(jwtProperties.getAccessTokenExpirationPeriodDay() / 1000);
+        cookieUtils.setAccessTokenCookie(httpResponse, response.accessToken(), maxAge);
         return BaseResponse.onSuccess(response);
     }
 
     @PostMapping("/admin/logout")
-    @Override
-    public BaseResponse<Void> adminLogout(@AccessToken String token) {
+    public BaseResponse<Void> adminLogout(
+            @AccessToken String token,
+            HttpServletResponse httpResponse) {
         adminLogoutUseCase.execute(token);
+        cookieUtils.clearAccessTokenCookie(httpResponse);
         return BaseResponse.onSuccess();
     }
 

--- a/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ExamResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ExamResponse.java
@@ -12,9 +12,15 @@ public record ExamResponse(
     LocalDateTime startsAt,
     LocalDateTime endsAt,
     Integer version,
-    Long createdBy
+    Long createdBy,
+    long participantCount,
+    long completedCount
 ) {
     public static ExamResponse from(Exam exam) {
+        return from(exam, 0L, 0L);
+    }
+
+    public static ExamResponse from(Exam exam, long participantCount, long completedCount) {
         return new ExamResponse(
             exam.getId(),
             exam.getTitle(),
@@ -22,7 +28,9 @@ public record ExamResponse(
             exam.getStartsAt(),
             exam.getEndsAt(),
             exam.getVersion(),
-            exam.getCreatedBy()
+            exam.getCreatedBy(),
+            participantCount,
+            completedCount
         );
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/exam/domain/repository/ExamParticipantRepository.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/domain/repository/ExamParticipantRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
 
@@ -22,4 +24,7 @@ public interface ExamParticipantRepository extends JpaRepository<ExamParticipant
     boolean existsByExamIdAndParticipantId(Long examId, Long participantId);
 
     long countByExamId(Long examId);
+
+    @Query("SELECT ep.examId, COUNT(ep) FROM ExamParticipant ep WHERE ep.examId IN :examIds GROUP BY ep.examId")
+    List<Object[]> countGroupByExamIdIn(@Param("examIds") List<Long> examIds);
 }

--- a/src/main/java/com/yd/vibecode/domain/exam/domain/repository/ExamParticipantRepository.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/domain/repository/ExamParticipantRepository.java
@@ -20,5 +20,6 @@ public interface ExamParticipantRepository extends JpaRepository<ExamParticipant
     List<ExamParticipant> findByParticipantIdOrderByJoinedAtDesc(Long participantId);
 
     boolean existsByExamIdAndParticipantId(Long examId, Long participantId);
-}
 
+    long countByExamId(Long examId);
+}

--- a/src/main/java/com/yd/vibecode/domain/submission/domain/repository/SubmissionRepository.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/domain/repository/SubmissionRepository.java
@@ -1,6 +1,8 @@
 package com.yd.vibecode.domain.submission.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.yd.vibecode.domain.submission.domain.entity.Submission;
 
@@ -16,4 +18,7 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     List<Submission> findByParticipantId(Long participantId);
 
     long countByExamId(Long examId);
+
+    @Query("SELECT s.examId, COUNT(s) FROM Submission s WHERE s.examId IN :examIds GROUP BY s.examId")
+    List<Object[]> countGroupByExamIdIn(@Param("examIds") List<Long> examIds);
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/domain/repository/SubmissionRepository.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/domain/repository/SubmissionRepository.java
@@ -14,4 +14,6 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     List<Submission> findByExamId(Long examId);
     
     List<Submission> findByParticipantId(Long participantId);
+
+    long countByExamId(Long examId);
 }

--- a/src/main/java/com/yd/vibecode/global/security/TokenProvider.java
+++ b/src/main/java/com/yd/vibecode/global/security/TokenProvider.java
@@ -23,6 +23,7 @@ import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import com.yd.vibecode.global.util.CookieUtils;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -124,7 +125,7 @@ public class TokenProvider {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                if ("access_token".equals(cookie.getName())) {
+                if (CookieUtils.ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
                     String value = cookie.getValue();
                     if (value != null && !value.isBlank()) {
                         return Optional.of(value);

--- a/src/main/java/com/yd/vibecode/global/security/TokenProvider.java
+++ b/src/main/java/com/yd/vibecode/global/security/TokenProvider.java
@@ -23,6 +23,7 @@ import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
@@ -119,9 +120,22 @@ public class TokenProvider {
 
 
     public Optional<String> getToken(HttpServletRequest request) {
+        // 1) HttpOnly 쿠키 우선
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("access_token".equals(cookie.getName())) {
+                    String value = cookie.getValue();
+                    if (value != null && !value.isBlank()) {
+                        return Optional.of(value);
+                    }
+                }
+            }
+        }
+        // 2) Authorization: Bearer 헤더 폴백 (STOMP 등 하위 호환)
         return Optional.ofNullable(request.getHeader(TOKEN_HEADER))
                 .filter(token -> token.startsWith(BEARER))
-                .map(token -> token.replace(BEARER, ""));
+                .map(token -> token.substring(BEARER.length()));
     }
 
     private Claims getClaims(String token) {

--- a/src/main/java/com/yd/vibecode/global/swagger/AuthApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/AuthApi.java
@@ -8,6 +8,7 @@ import com.yd.vibecode.domain.auth.application.dto.response.EnterResponse;
 import com.yd.vibecode.domain.auth.application.dto.response.MeResponse;
 import com.yd.vibecode.global.annotation.AccessToken;
 import com.yd.vibecode.global.common.BaseResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -38,7 +39,7 @@ public interface AuthApi extends BaseApi {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class))
             )
     })
-    BaseResponse<EnterResponse> enter(EnterRequest request);
+    BaseResponse<EnterResponse> enter(EnterRequest request, HttpServletResponse httpResponse);
 
     @Operation(
             summary = "관리자 회원가입",
@@ -74,7 +75,7 @@ public interface AuthApi extends BaseApi {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class))
             )
     })
-    BaseResponse<AdminLoginResponse> adminLogin(AdminLoginRequest request);
+    BaseResponse<AdminLoginResponse> adminLogin(AdminLoginRequest request, HttpServletResponse httpResponse);
 
     @Operation(
         summary = "관리자 로그아웃",
@@ -91,7 +92,7 @@ public interface AuthApi extends BaseApi {
                     content = @Content(schema = @Schema(implementation = BaseResponse.class))
             )
     })
-    BaseResponse<Void> adminLogout(@Parameter(hidden = true, in = ParameterIn.HEADER) @AccessToken String token);
+    BaseResponse<Void> adminLogout(@Parameter(hidden = true, in = ParameterIn.HEADER) @AccessToken String token, HttpServletResponse httpResponse);
 
     @Operation(
             summary = "내 정보 조회",

--- a/src/main/java/com/yd/vibecode/global/util/CookieUtils.java
+++ b/src/main/java/com/yd/vibecode/global/util/CookieUtils.java
@@ -1,0 +1,50 @@
+package com.yd.vibecode.global.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtils {
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+
+    @Value("${cookie.secure:true}")
+    private boolean secure;
+
+    /**
+     * HttpOnly access_token 쿠키를 응답에 추가한다.
+     *
+     * @param response      HttpServletResponse
+     * @param token         JWT access token 값
+     * @param maxAgeSeconds 만료 시간 (초)
+     */
+    public void setAccessTokenCookie(HttpServletResponse response, String token, int maxAgeSeconds) {
+        // SameSite는 Servlet API로 설정 불가 → Set-Cookie 헤더로 직접 구성 (단일 경로)
+        String cookieHeader = buildSetCookieHeader(token, maxAgeSeconds);
+        response.addHeader("Set-Cookie", cookieHeader);
+    }
+
+    /**
+     * access_token 쿠키를 삭제한다 (maxAge=0).
+     *
+     * @param response HttpServletResponse
+     */
+    public void clearAccessTokenCookie(HttpServletResponse response) {
+        String cookieHeader = buildSetCookieHeader("", 0);
+        response.addHeader("Set-Cookie", cookieHeader);
+    }
+
+    private String buildSetCookieHeader(String value, int maxAge) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(ACCESS_TOKEN_COOKIE_NAME).append("=").append(value);
+        sb.append("; Path=/");
+        sb.append("; Max-Age=").append(maxAge);
+        sb.append("; HttpOnly");
+        sb.append("; SameSite=Strict");
+        if (secure) {
+            sb.append("; Secure");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/yd/vibecode/global/util/CookieUtils.java
+++ b/src/main/java/com/yd/vibecode/global/util/CookieUtils.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class CookieUtils {
 
-    private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+    public static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
 
     @Value("${cookie.secure:true}")
     private boolean secure;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,10 +68,14 @@ exclude-blacklist-path-patterns:
 
 # CORS 설정
 cors:
-  allowed-origins: "http://localhost:5173,http://localhost:3000,http://localhost:8080,http://127.0.0.1:8080,http://localhost:8000,http://127.0.0.1:8000"
+  allowed-origins: "${CORS_ALLOWED_ORIGINS:http://localhost:5173,http://localhost:3000,http://127.0.0.1:3000,http://localhost:8080,http://127.0.0.1:8080,http://localhost:8000,http://127.0.0.1:8000,https://vibetest.codes,https://www.vibetest.codes}"
   allowed-methods: "GET,POST,PUT,PATCH,DELETE,OPTIONS,HEAD"
   allowed-headers: "Authorization,Content-Type,Accept,Origin,X-Requested-With,Access-Control-Request-Method,Access-Control-Request-Headers"
   max-age: 3600
+
+# 쿠키 설정
+cookie:
+  secure: ${COOKIE_SECURE:true}
 
 # Swagger 설정
 springdoc:

--- a/src/test/java/com/yd/vibecode/domain/admin/application/usecase/GetExamsUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/application/usecase/GetExamsUseCaseTest.java
@@ -17,13 +17,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.yd.vibecode.domain.exam.application.dto.response.ExamResponse;
 import com.yd.vibecode.domain.exam.domain.entity.Exam;
 import com.yd.vibecode.domain.exam.domain.entity.ExamState;
+import com.yd.vibecode.domain.exam.domain.repository.ExamParticipantRepository;
 import com.yd.vibecode.domain.exam.domain.repository.ExamRepository;
+import com.yd.vibecode.domain.submission.domain.repository.SubmissionRepository;
 
 @ExtendWith(MockitoExtension.class)
 class GetExamsUseCaseTest {
 
     @Mock
     private ExamRepository examRepository;
+    @Mock
+    private ExamParticipantRepository examParticipantRepository;
+    @Mock
+    private SubmissionRepository submissionRepository;
 
     @InjectMocks
     private GetExamsUseCase getExamsUseCase;
@@ -40,6 +46,7 @@ class GetExamsUseCaseTest {
             .version(0)
             .createdBy(1L)
             .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(exam1, "id", 1L);
 
         Exam exam2 = Exam.builder()
             .title("Test Exam 2")
@@ -49,9 +56,14 @@ class GetExamsUseCaseTest {
             .version(1)
             .createdBy(1L)
             .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(exam2, "id", 2L);
 
         given(examRepository.findAll())
             .willReturn(List.of(exam1, exam2));
+        given(examParticipantRepository.countByExamId(1L)).willReturn(3L);
+        given(examParticipantRepository.countByExamId(2L)).willReturn(5L);
+        given(submissionRepository.countByExamId(1L)).willReturn(1L);
+        given(submissionRepository.countByExamId(2L)).willReturn(4L);
 
         // when
         List<ExamResponse> result = getExamsUseCase.execute();
@@ -60,9 +72,17 @@ class GetExamsUseCaseTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(0).title()).isEqualTo("Test Exam 1");
         assertThat(result.get(0).state()).isEqualTo(ExamState.WAITING);
+        assertThat(result.get(0).participantCount()).isEqualTo(3L);
+        assertThat(result.get(0).completedCount()).isEqualTo(1L);
         assertThat(result.get(1).title()).isEqualTo("Test Exam 2");
         assertThat(result.get(1).state()).isEqualTo(ExamState.RUNNING);
+        assertThat(result.get(1).participantCount()).isEqualTo(5L);
+        assertThat(result.get(1).completedCount()).isEqualTo(4L);
         verify(examRepository).findAll();
+        verify(examParticipantRepository).countByExamId(1L);
+        verify(examParticipantRepository).countByExamId(2L);
+        verify(submissionRepository).countByExamId(1L);
+        verify(submissionRepository).countByExamId(2L);
     }
 
     @Test

--- a/src/test/java/com/yd/vibecode/domain/auth/ui/AuthControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/ui/AuthControllerTest.java
@@ -1,31 +1,32 @@
 package com.yd.vibecode.domain.auth.ui;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.jupiter.api.Disabled;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yd.vibecode.domain.auth.application.dto.request.AdminLoginRequest;
-import com.yd.vibecode.domain.auth.application.dto.request.AdminSignupRequest;
 import com.yd.vibecode.domain.auth.application.dto.request.EnterRequest;
 import com.yd.vibecode.domain.auth.application.dto.response.AdminLoginResponse;
 import com.yd.vibecode.domain.auth.application.dto.response.EnterResponse;
 import com.yd.vibecode.domain.auth.application.dto.response.MeResponse;
 import com.yd.vibecode.domain.auth.application.usecase.AdminLoginUseCase;
+import com.yd.vibecode.domain.auth.application.usecase.AdminLogoutUseCase;
 import com.yd.vibecode.domain.auth.application.usecase.AdminSignupUseCase;
 import com.yd.vibecode.domain.auth.application.usecase.EnterUseCase;
 import com.yd.vibecode.domain.auth.application.usecase.MeUseCase;
-import com.yd.vibecode.domain.auth.domain.service.TokenBlacklistService;
-import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
-import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
+import com.yd.vibecode.global.security.JwtProperties;
 import com.yd.vibecode.global.security.TokenProvider;
+import com.yd.vibecode.global.util.CookieUtils;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,11 +34,18 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * AuthController 단위 테스트
+ *
+ * - HttpOnly 쿠키 전환 이후 Set-Cookie 헤더 검증
+ * - @AccessToken 리졸버는 WebMvcTest 컨텍스트에서 TokenProvider mock으로 동작
+ * - CookieUtils / JwtProperties 는 MockBean으로 주입해 실제 쿠키 세팅 없이 호출 여부만 확인
+ */
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false) // Security Filter 비활성화
-@Disabled("WebMvcTest requires additional configuration for interceptors and properties")
 class AuthControllerTest {
 
     @Autowired
@@ -46,6 +54,7 @@ class AuthControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    // ---- UseCase MockBeans ----
     @MockBean
     private EnterUseCase enterUseCase;
     @MockBean
@@ -53,16 +62,35 @@ class AuthControllerTest {
     @MockBean
     private AdminLoginUseCase adminLoginUseCase;
     @MockBean
+    private AdminLogoutUseCase adminLogoutUseCase;
+    @MockBean
     private MeUseCase meUseCase;
+
+    // ---- Infrastructure MockBeans ----
     @MockBean
     private TokenProvider tokenProvider;
+    @MockBean
+    private CookieUtils cookieUtils;
+    @MockBean
+    private JwtProperties jwtProperties;
+
+    @BeforeEach
+    void setUpJwtProperties() {
+        // accessTokenExpirationPeriodDay = 3,600,000 ms (1시간) 기본값 설정
+        given(jwtProperties.getAccessTokenExpirationPeriodDay()).willReturn(3_600_000L);
+        // CookieUtils는 void 메서드 — 기본적으로 아무것도 하지 않으므로 별도 stub 불필요
+    }
+
+    // =========================================================================
+    // 1. POST /api/auth/enter — 사용자 입장
+    // =========================================================================
 
     @Test
-    @DisplayName("입장 API 테스트")
+    @DisplayName("입장 API — 응답 바디에 accessToken 포함, cookieUtils.setAccessTokenCookie 호출 확인")
     void enter_api_success() throws Exception {
         // given
         EnterRequest request = new EnterRequest("CODE", "홍길동", "010-1234-5678");
-        EnterResponse response = new EnterResponse("token", "USER", null, null, null);
+        EnterResponse response = new EnterResponse("test-token", "USER", null, null, null);
         given(enterUseCase.execute(any(EnterRequest.class))).willReturn(response);
 
         // when & then
@@ -70,15 +98,38 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.accessToken").value("token"));
+                .andExpect(jsonPath("$.result.accessToken").value("test-token"));
+
+        // CookieUtils.setAccessTokenCookie 가 호출됐는지 검증
+        verify(cookieUtils).setAccessTokenCookie(
+                any(HttpServletResponse.class),
+                eq("test-token"),
+                eq(3600) // 3_600_000 ms / 1000
+        );
     }
 
     @Test
-    @DisplayName("관리자 로그인 API 테스트")
+    @DisplayName("입장 API — 요청 필드 누락 시 400 Bad Request")
+    void enter_api_missing_fields_returns_400() throws Exception {
+        // 이름 필드가 null인 요청
+        String body = "{\"code\":\"CODE\",\"phone\":\"010-1234-5678\"}";
+
+        mockMvc.perform(post("/api/auth/enter")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    // =========================================================================
+    // 2. POST /api/auth/admin/login — 관리자 로그인
+    // =========================================================================
+
+    @Test
+    @DisplayName("관리자 로그인 API — 응답 바디에 accessToken 포함, cookieUtils.setAccessTokenCookie 호출 확인")
     void admin_login_api_success() throws Exception {
         // given
         AdminLoginRequest request = new AdminLoginRequest("admin", "password");
-        AdminLoginResponse response = new AdminLoginResponse("token", "ADMIN", null);
+        AdminLoginResponse response = new AdminLoginResponse("admin-token", "ADMIN", null);
         given(adminLoginUseCase.execute(any(AdminLoginRequest.class))).willReturn(response);
 
         // when & then
@@ -86,16 +137,76 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.accessToken").value("token"));
+                .andExpect(jsonPath("$.result.accessToken").value("admin-token"));
+
+        verify(cookieUtils).setAccessTokenCookie(
+                any(HttpServletResponse.class),
+                eq("admin-token"),
+                eq(3600)
+        );
+    }
+
+    // =========================================================================
+    // 3. POST /api/auth/admin/logout — 관리자 로그아웃
+    // =========================================================================
+
+    @Test
+    @DisplayName("관리자 로그아웃 API — clearAccessTokenCookie 호출, 200 OK")
+    void admin_logout_api_success() throws Exception {
+        // given — @AccessToken 리졸버가 TokenProvider.getToken() 으로 토큰을 꺼냄
+        String token = "valid-admin-token";
+        given(tokenProvider.getToken(any())).willReturn(Optional.of(token));
+        given(tokenProvider.isAccessToken(token)).willReturn(true);
+        willDoNothing().given(adminLogoutUseCase).execute(token);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/admin/logout")
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+
+        verify(adminLogoutUseCase).execute(token);
+        verify(cookieUtils).clearAccessTokenCookie(any(HttpServletResponse.class));
     }
 
     @Test
-    @DisplayName("내 정보 조회 API 테스트")
-    void me_api_success() throws Exception {
-        // given
-        String token = "token";
+    @DisplayName("관리자 로그아웃 API — 토큰 없을 시 401 Unauthorized")
+    void admin_logout_api_no_token_returns_401() throws Exception {
+        // given — 토큰이 없으면 리졸버가 RestApiException(_UNAUTHORIZED) 를 던짐
+        given(tokenProvider.getToken(any())).willReturn(Optional.empty());
+
+        mockMvc.perform(post("/api/auth/admin/logout"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // =========================================================================
+    // 4. GET /api/auth/me — 내 정보 조회
+    // =========================================================================
+
+    @Test
+    @DisplayName("내 정보 조회 API — 쿠키 토큰으로 조회 성공")
+    void me_api_success_with_cookie_token() throws Exception {
+        // given — 쿠키 우선 경로 시뮬레이션
+        String token = "cookie-token";
         MeResponse response = new MeResponse("USER", null, null, null);
         given(tokenProvider.getToken(any())).willReturn(Optional.of(token));
+        given(tokenProvider.isAccessToken(token)).willReturn(true);
+        given(meUseCase.execute(token)).willReturn(response);
+
+        // when & then — 쿠키로 요청 (Authorization 헤더 없음)
+        mockMvc.perform(get("/api/auth/me")
+                        .cookie(new jakarta.servlet.http.Cookie("access_token", token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.role").value("USER"));
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 API — Authorization 헤더 폴백 성공")
+    void me_api_success_with_bearer_token() throws Exception {
+        // given — 쿠키 없이 Bearer 헤더만 있을 때
+        String token = "header-token";
+        MeResponse response = new MeResponse("USER", null, null, null);
+        given(tokenProvider.getToken(any())).willReturn(Optional.of(token));
+        given(tokenProvider.isAccessToken(token)).willReturn(true);
         given(meUseCase.execute(token)).willReturn(response);
 
         // when & then
@@ -103,5 +214,106 @@ class AuthControllerTest {
                         .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.role").value("USER"));
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 API — 토큰 없을 시 401 Unauthorized")
+    void me_api_no_token_returns_401() throws Exception {
+        given(tokenProvider.getToken(any())).willReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/auth/me"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // =========================================================================
+    // 5. 토큰 우선순위 엣지 케이스 — TokenProvider getToken 로직 단위 검증
+    // =========================================================================
+
+    @Test
+    @DisplayName("TokenProvider — 쿠키와 Bearer 헤더 동시 존재 시 쿠키 우선")
+    void token_provider_prefers_cookie_over_header() {
+        // given
+        TokenProvider realProvider = buildRealTokenProvider();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        jakarta.servlet.http.Cookie cookie = new jakarta.servlet.http.Cookie("access_token", "cookie-val");
+        request.setCookies(cookie);
+        request.addHeader("Authorization", "Bearer header-val");
+
+        // when
+        Optional<String> token = realProvider.getToken(request);
+
+        // then
+        assert token.isPresent();
+        assert "cookie-val".equals(token.get()) : "쿠키가 헤더보다 우선되어야 한다";
+    }
+
+    @Test
+    @DisplayName("TokenProvider — 빈 쿠키 값일 때 Bearer 헤더 폴백")
+    void token_provider_falls_back_to_header_when_cookie_blank() {
+        // given
+        TokenProvider realProvider = buildRealTokenProvider();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        jakarta.servlet.http.Cookie blankCookie = new jakarta.servlet.http.Cookie("access_token", "   ");
+        request.setCookies(blankCookie);
+        request.addHeader("Authorization", "Bearer header-val");
+
+        // when
+        Optional<String> token = realProvider.getToken(request);
+
+        // then
+        assert token.isPresent();
+        assert "header-val".equals(token.get()) : "빈 쿠키 값이면 헤더로 폴백해야 한다";
+    }
+
+    @Test
+    @DisplayName("TokenProvider — 쿠키도 헤더도 없을 때 Optional.empty()")
+    void token_provider_returns_empty_when_no_token() {
+        // given
+        TokenProvider realProvider = buildRealTokenProvider();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // when
+        Optional<String> token = realProvider.getToken(request);
+
+        // then
+        assert token.isEmpty() : "토큰이 없을 때 Optional.empty() 여야 한다";
+    }
+
+    @Test
+    @DisplayName("TokenProvider — null 쿠키 값일 때 Bearer 헤더 폴백")
+    void token_provider_falls_back_to_header_when_cookie_value_null() {
+        // given
+        TokenProvider realProvider = buildRealTokenProvider();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // MockHttpServletRequest는 null 쿠키 값을 직접 지원하지 않으므로
+        // 쿠키 없이 헤더만 설정해 폴백 경로 검증
+        request.addHeader("Authorization", "Bearer fallback-token");
+
+        // when
+        Optional<String> token = realProvider.getToken(request);
+
+        // then
+        assert token.isPresent();
+        assert "fallback-token".equals(token.get());
+    }
+
+    // =========================================================================
+    // Helper
+    // =========================================================================
+
+    /**
+     * TokenProvider 우선순위 로직 단위 검증에 사용할 실제 인스턴스를 생성한다.
+     * JwtProperties는 key/expiration 값이 불필요한 getToken() 경로만 테스트하므로
+     * 더미 값으로 구성한다.
+     */
+    private TokenProvider buildRealTokenProvider() {
+        JwtProperties props = new JwtProperties();
+        props.setKey("test-secret-key-32-characters-long!!");
+        props.setAccessTokenExpirationPeriodDay(3_600_000L);
+        props.setRefreshTokenExpirationPeriodDay(86_400_000L);
+        return new TokenProvider(props);
     }
 }

--- a/src/test/java/com/yd/vibecode/domain/auth/ui/AuthControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/ui/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.yd.vibecode.domain.auth.ui;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -244,8 +245,8 @@ class AuthControllerTest {
         Optional<String> token = realProvider.getToken(request);
 
         // then
-        assert token.isPresent();
-        assert "cookie-val".equals(token.get()) : "쿠키가 헤더보다 우선되어야 한다";
+        assertThat(token).isPresent();
+        assertThat(token.get()).isEqualTo("cookie-val");
     }
 
     @Test
@@ -263,8 +264,8 @@ class AuthControllerTest {
         Optional<String> token = realProvider.getToken(request);
 
         // then
-        assert token.isPresent();
-        assert "header-val".equals(token.get()) : "빈 쿠키 값이면 헤더로 폴백해야 한다";
+        assertThat(token).isPresent();
+        assertThat(token.get()).isEqualTo("header-val");
     }
 
     @Test
@@ -278,7 +279,7 @@ class AuthControllerTest {
         Optional<String> token = realProvider.getToken(request);
 
         // then
-        assert token.isEmpty() : "토큰이 없을 때 Optional.empty() 여야 한다";
+        assertThat(token).isEmpty();
     }
 
     @Test
@@ -296,8 +297,8 @@ class AuthControllerTest {
         Optional<String> token = realProvider.getToken(request);
 
         // then
-        assert token.isPresent();
-        assert "fallback-token".equals(token.get());
+        assertThat(token).isPresent();
+        assertThat(token.get()).isEqualTo("fallback-token");
     }
 
     // =========================================================================


### PR DESCRIPTION
## 변경 사항

  ### 인증 쿠키 전환
  - `CookieUtils` 추가
    - `setAccessTokenCookie()`
    - `clearAccessTokenCookie()`
  - `AuthController`
    - `/api/auth/enter` 응답 시 `access_token` HttpOnly 쿠키 발급
    - `/api/auth/admin/login` 응답 시 `access_token` HttpOnly 쿠키 발급
    - `/api/auth/admin/logout` 응답 시 `access_token` 쿠키 삭제
  - `TokenProvider`
    - 토큰 조회 우선순위를 `access_token` 쿠키 우선으로 변경
    - `Authorization: Bearer` 헤더는 폴백으로 유지
  - `AuthApi`
    - `HttpServletResponse` 파라미터 반영
  - `application.yml`
    - `cookie.secure` 설정 추가
    - CORS 기본 허용 origin 정리 및 `127.0.0.1:3000` 포함

  ### 시험 목록 집계 필드 추가
  - `ExamResponse`
    - `participantCount`
    - `completedCount`
  - `GetExamsUseCase`
    - 시험별 참가자 수를 `ExamParticipantRepository.countByExamId()`로 집계
    - 시험별 완료 수를 `SubmissionRepository.countByExamId()`로 집계
  - 관련 repository count 메서드 추가

  ### 테스트
  - `AuthControllerTest` 갱신
    - 쿠키 발급/삭제 경로 검증
    - 쿠키 우선, 헤더 폴백 시나리오 검증
  - `GetExamsUseCaseTest` 추가 보강
    - 시험별 참가자/완료 집계 검증
  - `AdminExamControllerTest` 갱신

  ## 확인 내용
  - `POST /api/auth/admin/login` 시 `Set-Cookie: access_token=...` 확인
  - 쿠키만으로 `/api/auth/me` 호출 성공 확인
  - `POST /api/auth/admin/logout` 시 삭제 쿠키 응답 확인
  - `GET /api/admin/exams` 응답에 `participantCount`, `completedCount` 포함 확인
  - 대상 테스트 실행:
    - `./gradlew test --tests com.yd.vibecode.domain.admin.application.usecase.GetExamsUseCaseTest --tests com.yd.vibecode.domain.exam.ui.AdminExamControllerTest`

  ## 참고
  - 현재 로컬 DB 기준 `submissions` 데이터가 없어 `completedCount`는 모두 `0`으로 확인됨
  - 값 자체는 submission row 수 기준으로 집계되도록 반영함