### PR TITLE
fix: EntryCode tokenLimit 필드 분리 및 시험 시작 시 참가자 동기화

### DIFF
--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/request/CreateEntryCodeRequest.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/request/CreateEntryCodeRequest.java
@@ -25,6 +25,9 @@ public record CreateEntryCodeRequest(
     LocalDateTime expiresAt,
     
     @Min(value = 0, message = "최대 사용 횟수는 0 이상이어야 합니다.")
-    Integer maxUses
+    Integer maxUses,
+
+    @Min(value = 1, message = "토큰 한도는 1 이상이어야 합니다.")
+    Integer tokenLimit
 ) {
 }

--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/request/UpdateEntryCodeRequest.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/request/UpdateEntryCodeRequest.java
@@ -1,7 +1,10 @@
 package com.yd.vibecode.domain.admin.application.dto.request;
 
+import jakarta.validation.constraints.Min;
+
 public record UpdateEntryCodeRequest(
     Boolean isActive,
+    @Min(value = 1, message = "토큰 한도는 1 이상이어야 합니다.")
     Integer tokenLimit
 ) {
 }

--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/request/UpdateEntryCodeRequest.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/request/UpdateEntryCodeRequest.java
@@ -1,6 +1,7 @@
 package com.yd.vibecode.domain.admin.application.dto.request;
 
 public record UpdateEntryCodeRequest(
-    Boolean isActive
+    Boolean isActive,
+    Integer tokenLimit
 ) {
 }

--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/EntryCodeResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/EntryCodeResponse.java
@@ -11,7 +11,8 @@ public record EntryCodeResponse(
     LocalDateTime expiresAt,
     Integer maxUses,
     Integer usedCount,
-    Boolean isActive
+    Boolean isActive,
+    Integer tokenLimit
 ) {
     public static EntryCodeResponse from(EntryCode entryCode) {
         return new EntryCodeResponse(
@@ -22,7 +23,8 @@ public record EntryCodeResponse(
             entryCode.getExpiresAt(),
             entryCode.getMaxUses(),
             entryCode.getUsedCount(),
-            entryCode.getIsActive()
+            entryCode.getIsActive(),
+            entryCode.getTokenLimit()
         );
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/CreateEntryCodeUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/CreateEntryCodeUseCase.java
@@ -38,6 +38,7 @@ public class CreateEntryCodeUseCase {
             .label(request.label())
             .expiresAt(request.expiresAt())
             .maxUses(request.maxUses())
+            .tokenLimit(request.tokenLimit())
             .isActive(true)
             .build();
 

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/UpdateEntryCodeUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/UpdateEntryCodeUseCase.java
@@ -20,6 +20,7 @@ public class UpdateEntryCodeUseCase {
 
         // request.isActive() 값에 따라 활성/비활성 처리 (코드 재발급 없음)
         entryCode.update(request.isActive());
+        entryCode.updateTokenLimit(request.tokenLimit());
 
         return EntryCodeResponse.from(entryCode);
     }

--- a/src/main/java/com/yd/vibecode/domain/auth/application/usecase/EnterUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/application/usecase/EnterUseCase.java
@@ -77,7 +77,7 @@ public class EnterUseCase {
                     entryCode.getExamId(),
                     user.getId(),
                     specId,
-                    entryCode.getMaxUses() > 0 ? entryCode.getMaxUses() * 1000 : 20000, // 기본 토큰 한도
+                    entryCode.getTokenLimit(),
                     assignedProblemId
             );
         }

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/entity/EntryCode.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/entity/EntryCode.java
@@ -45,11 +45,15 @@ public class EntryCode extends BaseEntity {
     private Integer usedCount = 0;
 
     @Column(nullable = false)
+    private Integer tokenLimit = 20000;
+
+    @Column(nullable = false)
     private Boolean isActive = true;
 
     @Builder
     public EntryCode(String code, Long examId, Long problemSetId, Long createdBy, String label,
-                     LocalDateTime expiresAt, Integer maxUses, Integer usedCount, Boolean isActive) {
+                     LocalDateTime expiresAt, Integer maxUses, Integer usedCount, Boolean isActive,
+                     Integer tokenLimit) {
         this.code = code;
         this.examId = examId;
         this.problemSetId = problemSetId;
@@ -59,6 +63,7 @@ public class EntryCode extends BaseEntity {
         this.maxUses = maxUses != null ? maxUses : 0;
         this.usedCount = usedCount != null ? usedCount : 0;
         this.isActive = isActive != null ? isActive : true;
+        this.tokenLimit = tokenLimit != null ? tokenLimit : 20000;
     }
 
     public void incrementUsedCount() {
@@ -72,6 +77,12 @@ public class EntryCode extends BaseEntity {
     public void update(Boolean isActive) {
         if (isActive != null) {
             this.isActive = isActive;
+        }
+    }
+
+    public void updateTokenLimit(Integer tokenLimit) {
+        if (tokenLimit != null && tokenLimit > 0) {
+            this.tokenLimit = tokenLimit;
         }
     }
 

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/repository/EntryCodeRepository.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/repository/EntryCodeRepository.java
@@ -14,5 +14,7 @@ public interface EntryCodeRepository extends JpaRepository<EntryCode, String> {
     List<EntryCode> findByExamId(Long examId);
 
     List<EntryCode> findByExamIdAndIsActive(Long examId, Boolean isActive);
+
+    Optional<EntryCode> findTopByExamIdAndIsActiveOrderByCreatedAtDesc(Long examId, Boolean isActive);
 }
 

--- a/src/main/java/com/yd/vibecode/domain/auth/ui/AuthController.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/ui/AuthController.java
@@ -1,5 +1,7 @@
 package com.yd.vibecode.domain.auth.ui;
 
+import java.time.Duration;
+
 import com.yd.vibecode.domain.auth.application.dto.request.AdminLoginRequest;
 import com.yd.vibecode.domain.auth.application.dto.request.AdminSignupRequest;
 import com.yd.vibecode.domain.auth.application.dto.request.EnterRequest;
@@ -11,11 +13,16 @@ import com.yd.vibecode.domain.auth.application.usecase.AdminLogoutUseCase;
 import com.yd.vibecode.domain.auth.application.usecase.AdminSignupUseCase;
 import com.yd.vibecode.domain.auth.application.usecase.EnterUseCase;
 import com.yd.vibecode.domain.auth.application.usecase.MeUseCase;
+import com.yd.vibecode.domain.auth.domain.service.RefreshTokenService;
 import com.yd.vibecode.global.annotation.AccessToken;
-import com.yd.vibecode.global.swagger.AuthApi;
 import com.yd.vibecode.global.common.BaseResponse;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
 import com.yd.vibecode.global.security.JwtProperties;
+import com.yd.vibecode.global.security.TokenProvider;
+import com.yd.vibecode.global.swagger.AuthApi;
 import com.yd.vibecode.global.util.CookieUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +44,8 @@ public class AuthController implements AuthApi {
     private final MeUseCase meUseCase;
     private final CookieUtils cookieUtils;
     private final JwtProperties jwtProperties;
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @PostMapping("/enter")
     public BaseResponse<EnterResponse> enter(
@@ -62,8 +71,17 @@ public class AuthController implements AuthApi {
             @Valid @RequestBody AdminLoginRequest request,
             HttpServletResponse httpResponse) {
         AdminLoginResponse response = adminLoginUseCase.execute(request);
-        int maxAge = Math.toIntExact(jwtProperties.getAccessTokenExpirationPeriodDay() / 1000);
-        cookieUtils.setAccessTokenCookie(httpResponse, response.accessToken(), maxAge);
+        int accessMaxAge = Math.toIntExact(jwtProperties.getAccessTokenExpirationPeriodDay() / 1000);
+        cookieUtils.setAccessTokenCookie(httpResponse, response.accessToken(), accessMaxAge);
+
+        // admin 전용 refresh token 발급: HttpOnly 쿠키로만 전달 (body 노출 불필요)
+        String adminId = tokenProvider.getId(response.accessToken()).orElseThrow();
+        String refreshToken = tokenProvider.createRefreshToken(adminId);
+        Duration refreshDuration = Duration.ofMillis(jwtProperties.getRefreshTokenExpirationPeriodDay());
+        refreshTokenService.saveRefreshToken(adminId, refreshToken, refreshDuration);
+        int refreshMaxAge = Math.toIntExact(jwtProperties.getRefreshTokenExpirationPeriodDay() / 1000);
+        cookieUtils.setRefreshTokenCookie(httpResponse, refreshToken, refreshMaxAge);
+
         return BaseResponse.onSuccess(response);
     }
 
@@ -73,6 +91,40 @@ public class AuthController implements AuthApi {
             HttpServletResponse httpResponse) {
         adminLogoutUseCase.execute(token);
         cookieUtils.clearAccessTokenCookie(httpResponse);
+        cookieUtils.clearRefreshTokenCookie(httpResponse);
+        return BaseResponse.onSuccess();
+    }
+
+    @PostMapping("/admin/reissue")
+    public BaseResponse<Void> adminReissue(HttpServletRequest request, HttpServletResponse httpResponse) {
+        String refreshToken = cookieUtils.getRefreshTokenFromRequest(request);
+        if (refreshToken == null) {
+            throw new RestApiException(AuthErrorStatus.EMPTY_JWT);
+        }
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new RestApiException(AuthErrorStatus.EXPIRED_REFRESH_TOKEN);
+        }
+
+        String adminId = tokenProvider.getId(refreshToken)
+                .orElseThrow(() -> new RestApiException(AuthErrorStatus.INVALID_REFRESH_TOKEN));
+
+        if (!refreshTokenService.isExist(refreshToken, adminId)) {
+            throw new RestApiException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
+        }
+
+        // 토큰 로테이션: 기존 refresh token 삭제 후 신규 발급
+        refreshTokenService.deleteRefreshToken(adminId);
+        String newAccessToken = tokenProvider.createAccessToken(adminId, "ADMIN");
+        String newRefreshToken = tokenProvider.createRefreshToken(adminId);
+        Duration remaining = tokenProvider.getRemainingDuration(refreshToken)
+                .orElseThrow(() -> new RestApiException(AuthErrorStatus.EXPIRED_REFRESH_TOKEN));
+        refreshTokenService.saveRefreshToken(adminId, newRefreshToken, remaining);
+
+        int accessMaxAge = Math.toIntExact(jwtProperties.getAccessTokenExpirationPeriodDay() / 1000);
+        int refreshMaxAge = (int) Math.min(remaining.getSeconds(), Integer.MAX_VALUE);
+        cookieUtils.setAccessTokenCookie(httpResponse, newAccessToken, accessMaxAge);
+        cookieUtils.setRefreshTokenCookie(httpResponse, newRefreshToken, refreshMaxAge);
+
         return BaseResponse.onSuccess();
     }
 

--- a/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ParticipantSessionResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ParticipantSessionResponse.java
@@ -3,7 +3,7 @@ package com.yd.vibecode.domain.exam.application.dto.response;
 import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
 
 public record ParticipantSessionResponse(
-    Long participantId,
+    Long examParticipantId,
     Long examId,
     Integer tokenLimit,
     Integer tokenUsed,

--- a/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ParticipantSessionResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ParticipantSessionResponse.java
@@ -1,0 +1,23 @@
+package com.yd.vibecode.domain.exam.application.dto.response;
+
+import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
+
+public record ParticipantSessionResponse(
+    Long participantId,
+    Long examId,
+    Integer tokenLimit,
+    Integer tokenUsed,
+    Long specId,
+    Long assignedProblemId
+) {
+    public static ParticipantSessionResponse from(ExamParticipant participant) {
+        return new ParticipantSessionResponse(
+            participant.getId(),
+            participant.getExamId(),
+            participant.getTokenLimit(),
+            participant.getTokenUsed(),
+            participant.getSpecId(),
+            participant.getAssignedProblemId()
+        );
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/exam/application/usecase/GetParticipantSessionUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/usecase/GetParticipantSessionUseCase.java
@@ -1,0 +1,32 @@
+package com.yd.vibecode.domain.exam.application.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.yd.vibecode.domain.exam.application.dto.response.ParticipantSessionResponse;
+import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
+import com.yd.vibecode.domain.exam.domain.service.ExamParticipantService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.ExamErrorStatus;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 현재 로그인한 참가자의 세션 정보 조회 UseCase
+ * GET /api/exams/{examId}/participants/me
+ */
+@Service
+@RequiredArgsConstructor
+public class GetParticipantSessionUseCase {
+
+    private final ExamParticipantService examParticipantService;
+
+    @Transactional(readOnly = true)
+    public ParticipantSessionResponse execute(Long examId, Long participantId) {
+        ExamParticipant participant = examParticipantService.findByExamIdAndParticipantId(examId, participantId);
+        if (participant == null) {
+            throw new RestApiException(ExamErrorStatus.PARTICIPANT_NOT_FOUND);
+        }
+        return ParticipantSessionResponse.from(participant);
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/exam/application/usecase/StartExamUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/usecase/StartExamUseCase.java
@@ -1,12 +1,23 @@
 package com.yd.vibecode.domain.exam.application.usecase;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.yd.vibecode.domain.auth.domain.entity.EntryCode;
+import com.yd.vibecode.domain.auth.domain.repository.EntryCodeRepository;
 import com.yd.vibecode.domain.exam.application.dto.event.ExamStateEvent;
 import com.yd.vibecode.domain.exam.domain.entity.Exam;
+import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
+import com.yd.vibecode.domain.exam.domain.repository.ExamParticipantRepository;
 import com.yd.vibecode.domain.exam.domain.service.ExamService;
+import com.yd.vibecode.domain.problem.domain.entity.Problem;
+import com.yd.vibecode.domain.problem.domain.repository.ProblemRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
  * 시험 시작 UseCase
  * - 시험 상태를 WAITING -> RUNNING으로 변경
  * - version 증가
+ * - 대기 중인 모든 참가자의 specId를 문제의 최신 currentSpecId로 동기화
  * - WebSocket으로 상태 변경 브로드캐스트 (/topic/exam/{examId})
  */
 @Slf4j
@@ -24,13 +36,72 @@ public class StartExamUseCase {
 
     private final ExamService examService;
     private final SimpMessagingTemplate messagingTemplate;
+    private final ExamParticipantRepository examParticipantRepository;
+    private final ProblemRepository problemRepository;
+    private final EntryCodeRepository entryCodeRepository;
 
     @Transactional
     public void execute(Long examId) {
+        // 1. 참가자 specId 및 tokenLimit 동기화 (시험 상태 변경 전 처리)
+        syncParticipants(examId);
+
+        // 2. 시험 상태 변경 WAITING -> RUNNING
         Exam exam = examService.startExam(examId);
 
+        // 3. WebSocket 브로드캐스트
         ExamStateEvent event = ExamStateEvent.from(exam);
         messagingTemplate.convertAndSend("/topic/exam/" + examId, event);
         log.info("Exam started, WS broadcast sent: examId={}, version={}", examId, exam.getVersion());
+    }
+
+    /**
+     * 시험에 속한 모든 참가자의 specId와 tokenLimit을 최신 값으로 동기화한다.
+     * - specId: 참가자의 assignedProblemId 기준으로 문제의 currentSpecId를 적용
+     * - tokenLimit: 해당 시험의 활성 입장 코드 tokenLimit을 적용
+     * - 문제 조회는 IN 쿼리 1회로 처리해 N+1을 방지한다.
+     * - 복수의 활성 입장 코드가 있을 경우 첫 번째(최신)를 기준으로 한다.
+     */
+    private void syncParticipants(Long examId) {
+        List<ExamParticipant> participants = examParticipantRepository.findByExamId(examId);
+        if (participants.isEmpty()) {
+            return;
+        }
+
+        // 활성 입장 코드에서 tokenLimit 조회
+        List<EntryCode> activeCodes = entryCodeRepository.findByExamIdAndIsActive(examId, true);
+        Integer latestTokenLimit = activeCodes.isEmpty() ? null : activeCodes.get(0).getTokenLimit();
+
+        // 참가자가 배정받은 문제 ID를 수집해 IN 쿼리 1회로 일괄 조회 (N+1 방지)
+        Set<Long> problemIds = participants.stream()
+                .map(ExamParticipant::getAssignedProblemId)
+                .filter(id -> id != null)
+                .collect(Collectors.toSet());
+        Map<Long, Long> problemIdToSpecId = problemRepository.findAllById(problemIds).stream()
+                .filter(p -> p.getCurrentSpecId() != null)
+                .collect(Collectors.toMap(Problem::getId, Problem::getCurrentSpecId));
+
+        int syncedSpecId = 0;
+        int syncedTokenLimit = 0;
+
+        for (ExamParticipant participant : participants) {
+            // specId 동기화
+            Long assignedProblemId = participant.getAssignedProblemId();
+            if (assignedProblemId != null) {
+                Long currentSpecId = problemIdToSpecId.get(assignedProblemId);
+                if (currentSpecId != null && !currentSpecId.equals(participant.getSpecId())) {
+                    participant.updateSpecId(currentSpecId);
+                    syncedSpecId++;
+                }
+            }
+
+            // tokenLimit 동기화 (입장 코드의 최신 tokenLimit으로)
+            if (latestTokenLimit != null && !latestTokenLimit.equals(participant.getTokenLimit())) {
+                participant.updateTokenLimit(latestTokenLimit);
+                syncedTokenLimit++;
+            }
+        }
+
+        log.info("Participant sync completed: examId={}, totalParticipants={}, specIdSynced={}, tokenLimitSynced={}",
+                examId, participants.size(), syncedSpecId, syncedTokenLimit);
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/exam/application/usecase/StartExamUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/usecase/StartExamUseCase.java
@@ -2,6 +2,7 @@ package com.yd.vibecode.domain.exam.application.usecase;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -67,18 +68,20 @@ public class StartExamUseCase {
             return;
         }
 
-        // 활성 입장 코드에서 tokenLimit 조회
-        List<EntryCode> activeCodes = entryCodeRepository.findByExamIdAndIsActive(examId, true);
-        Integer latestTokenLimit = activeCodes.isEmpty() ? null : activeCodes.get(0).getTokenLimit();
+        // 활성 입장 코드에서 tokenLimit 조회 (가장 최근 생성된 코드 기준)
+        Optional<EntryCode> latestCode = entryCodeRepository.findTopByExamIdAndIsActiveOrderByCreatedAtDesc(examId, true);
+        Integer latestTokenLimit = latestCode.map(EntryCode::getTokenLimit).orElse(null);
 
         // 참가자가 배정받은 문제 ID를 수집해 IN 쿼리 1회로 일괄 조회 (N+1 방지)
         Set<Long> problemIds = participants.stream()
                 .map(ExamParticipant::getAssignedProblemId)
                 .filter(id -> id != null)
                 .collect(Collectors.toSet());
-        Map<Long, Long> problemIdToSpecId = problemRepository.findAllById(problemIds).stream()
-                .filter(p -> p.getCurrentSpecId() != null)
-                .collect(Collectors.toMap(Problem::getId, Problem::getCurrentSpecId));
+        Map<Long, Long> problemIdToSpecId = problemIds.isEmpty()
+                ? Map.of()
+                : problemRepository.findAllById(problemIds).stream()
+                        .filter(p -> p.getCurrentSpecId() != null)
+                        .collect(Collectors.toMap(Problem::getId, Problem::getCurrentSpecId));
 
         int syncedSpecId = 0;
         int syncedTokenLimit = 0;

--- a/src/main/java/com/yd/vibecode/domain/exam/domain/entity/ExamParticipant.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/domain/entity/ExamParticipant.java
@@ -89,6 +89,12 @@ public class ExamParticipant extends BaseEntity {
         this.assignedProblemId = problemId;
     }
 
+    public void updateTokenLimit(Integer tokenLimit) {
+        if (tokenLimit != null && tokenLimit > 0) {
+            this.tokenLimit = tokenLimit;
+        }
+    }
+
     public boolean isTokenLimitExceeded() {
         return tokenUsed >= tokenLimit;
     }

--- a/src/main/java/com/yd/vibecode/domain/exam/domain/service/ExamParticipantService.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/domain/service/ExamParticipantService.java
@@ -46,6 +46,14 @@ public class ExamParticipantService {
     }
 
     @Transactional
+    public void syncSpecIdForExam(Long examId, Long problemId, Long currentSpecId) {
+        examParticipantRepository.findByExamId(examId).stream()
+                .filter(p -> problemId.equals(p.getAssignedProblemId()))
+                .filter(p -> !currentSpecId.equals(p.getSpecId()))
+                .forEach(p -> p.updateSpecId(currentSpecId));
+    }
+
+    @Transactional
     public void endAllParticipants(Long examId) {
         examParticipantRepository.findByExamId(examId)
                 .forEach(participant -> participant.updateState("ENDED"));

--- a/src/main/java/com/yd/vibecode/domain/exam/domain/service/ExamParticipantService.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/domain/service/ExamParticipantService.java
@@ -1,6 +1,7 @@
 package com.yd.vibecode.domain.exam.domain.service;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,9 +48,12 @@ public class ExamParticipantService {
 
     @Transactional
     public void syncSpecIdForExam(Long examId, Long problemId, Long currentSpecId) {
+        if (problemId == null || currentSpecId == null) {
+            return;
+        }
         examParticipantRepository.findByExamId(examId).stream()
-                .filter(p -> problemId.equals(p.getAssignedProblemId()))
-                .filter(p -> !currentSpecId.equals(p.getSpecId()))
+                .filter(p -> Objects.equals(problemId, p.getAssignedProblemId()))
+                .filter(p -> !Objects.equals(currentSpecId, p.getSpecId()))
                 .forEach(p -> p.updateSpecId(currentSpecId));
     }
 

--- a/src/main/java/com/yd/vibecode/domain/exam/ui/ExamController.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/ui/ExamController.java
@@ -6,7 +6,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.yd.vibecode.domain.exam.application.dto.response.ExamStateResponse;
+import com.yd.vibecode.domain.exam.application.dto.response.ParticipantSessionResponse;
 import com.yd.vibecode.domain.exam.application.usecase.GetExamStateUseCase;
+import com.yd.vibecode.domain.exam.application.usecase.GetParticipantSessionUseCase;
+import com.yd.vibecode.global.annotation.CurrentUser;
 import com.yd.vibecode.global.common.BaseResponse;
 import com.yd.vibecode.global.swagger.ExamApi;
 
@@ -15,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 /**
  * 시험 관련 USER Controller
  * - GET /api/exams/{examId}/state: 시험 상태 조회 (타이머 동기화용)
+ * - GET /api/exams/{examId}/participants/me: 현재 참가자 세션 정보 조회
  */
 @RestController
 @RequiredArgsConstructor
@@ -22,11 +26,20 @@ import lombok.RequiredArgsConstructor;
 public class ExamController implements ExamApi {
 
     private final GetExamStateUseCase getExamStateUseCase;
+    private final GetParticipantSessionUseCase getParticipantSessionUseCase;
 
     @GetMapping("/{examId}/state")
     @Override
     public BaseResponse<ExamStateResponse> getExamState(@PathVariable Long examId) {
         ExamStateResponse response = getExamStateUseCase.execute(examId);
+        return BaseResponse.onSuccess(response);
+    }
+
+    @GetMapping("/{examId}/participants/me")
+    public BaseResponse<ParticipantSessionResponse> getMySession(
+            @PathVariable Long examId,
+            @CurrentUser String userId) {
+        ParticipantSessionResponse response = getParticipantSessionUseCase.execute(examId, Long.parseLong(userId));
         return BaseResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/yd/vibecode/global/exception/code/status/ExamErrorStatus.java
+++ b/src/main/java/com/yd/vibecode/global/exception/code/status/ExamErrorStatus.java
@@ -17,7 +17,8 @@ public enum ExamErrorStatus implements BaseCodeInterface {
     CANNOT_EXTEND_EXAM(HttpStatus.BAD_REQUEST, "EXAM003", "진행 중인 시험만 연장할 수 있습니다."),
     EXAM_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "EXAM004", "이미 시작된 시험입니다."),
     EXAM_ALREADY_ENDED(HttpStatus.BAD_REQUEST, "EXAM005", "이미 종료된 시험입니다."),
-    EXAM_NOT_STARTED(HttpStatus.BAD_REQUEST, "EXAM006", "시험이 아직 시작되지 않았습니다.")
+    EXAM_NOT_STARTED(HttpStatus.BAD_REQUEST, "EXAM006", "시험이 아직 시작되지 않았습니다."),
+    PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM007", "시험 참가자를 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/yd/vibecode/global/security/TokenProvider.java
+++ b/src/main/java/com/yd/vibecode/global/security/TokenProvider.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -40,6 +41,7 @@ public class TokenProvider {
     private static final String BEARER = "Bearer ";
     private static final String ID_CLAIM = "id";
     private static final String ROLE_CLAIM = "role";
+    private static final String JTI_CLAIM = "jti";
 
 
     public String createAccessToken(String id, String role) {
@@ -77,6 +79,7 @@ public class TokenProvider {
                 ))
                 .setSubject(REFRESH_TOKEN_SUBJECT)
                 .claim(ID_CLAIM, id)
+                .claim(JTI_CLAIM, UUID.randomUUID().toString())
                 .signWith(Keys.hmacShaKeyFor(jwtProperties.getKey().getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/com/yd/vibecode/global/util/CookieUtils.java
+++ b/src/main/java/com/yd/vibecode/global/util/CookieUtils.java
@@ -1,5 +1,7 @@
 package com.yd.vibecode.global.util;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -8,36 +10,45 @@ import org.springframework.stereotype.Component;
 public class CookieUtils {
 
     public static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
 
     @Value("${cookie.secure:true}")
     private boolean secure;
 
-    /**
-     * HttpOnly access_token 쿠키를 응답에 추가한다.
-     *
-     * @param response      HttpServletResponse
-     * @param token         JWT access token 값
-     * @param maxAgeSeconds 만료 시간 (초)
-     */
     public void setAccessTokenCookie(HttpServletResponse response, String token, int maxAgeSeconds) {
-        // SameSite는 Servlet API로 설정 불가 → Set-Cookie 헤더로 직접 구성 (단일 경로)
-        String cookieHeader = buildSetCookieHeader(token, maxAgeSeconds);
-        response.addHeader("Set-Cookie", cookieHeader);
+        response.addHeader("Set-Cookie", buildSetCookieHeader(ACCESS_TOKEN_COOKIE_NAME, token, maxAgeSeconds));
     }
 
-    /**
-     * access_token 쿠키를 삭제한다 (maxAge=0).
-     *
-     * @param response HttpServletResponse
-     */
     public void clearAccessTokenCookie(HttpServletResponse response) {
-        String cookieHeader = buildSetCookieHeader("", 0);
-        response.addHeader("Set-Cookie", cookieHeader);
+        response.addHeader("Set-Cookie", buildSetCookieHeader(ACCESS_TOKEN_COOKIE_NAME, "", 0));
     }
 
-    private String buildSetCookieHeader(String value, int maxAge) {
+    public void setRefreshTokenCookie(HttpServletResponse response, String token, int maxAgeSeconds) {
+        response.addHeader("Set-Cookie", buildSetCookieHeader(REFRESH_TOKEN_COOKIE_NAME, token, maxAgeSeconds));
+    }
+
+    public void clearRefreshTokenCookie(HttpServletResponse response) {
+        response.addHeader("Set-Cookie", buildSetCookieHeader(REFRESH_TOKEN_COOKIE_NAME, "", 0));
+    }
+
+    public String getRefreshTokenFromRequest(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                    String value = cookie.getValue();
+                    if (value != null && !value.isBlank()) {
+                        return value;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private String buildSetCookieHeader(String name, String value, int maxAge) {
         StringBuilder sb = new StringBuilder();
-        sb.append(ACCESS_TOKEN_COOKIE_NAME).append("=").append(value);
+        sb.append(name).append("=").append(value);
         sb.append("; Path=/");
         sb.append("; Max-Age=").append(maxAge);
         sb.append("; HttpOnly");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,8 @@ exclude-auth-path-patterns:
       method: POST
     - path-pattern: /api/auth/admin/login
       method: POST
+    - path-pattern: /api/auth/admin/reissue
+      method: POST
     - path-pattern: /swagger-ui.html
       method: GET
     - path-pattern: /swagger-ui/**

--- a/src/test/java/com/yd/vibecode/domain/admin/application/usecase/UpdateEntryCodeUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/application/usecase/UpdateEntryCodeUseCaseTest.java
@@ -72,7 +72,7 @@ class UpdateEntryCodeUseCaseTest {
         EntryCode entryCode = buildActiveEntryCode(code);
         given(entryCodeService.findByCode(code)).willReturn(entryCode);
 
-        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(false);
+        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(false, null);
 
         // when
         EntryCodeResponse response = updateEntryCodeUseCase.execute(code, request);
@@ -95,7 +95,7 @@ class UpdateEntryCodeUseCaseTest {
         EntryCode entryCode = buildInactiveEntryCode(code);
         given(entryCodeService.findByCode(code)).willReturn(entryCode);
 
-        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(true);
+        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(true, null);
 
         // when
         EntryCodeResponse response = updateEntryCodeUseCase.execute(code, request);
@@ -118,7 +118,7 @@ class UpdateEntryCodeUseCaseTest {
         EntryCode entryCode = buildActiveEntryCode(code);
         given(entryCodeService.findByCode(code)).willReturn(entryCode);
 
-        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(true);
+        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(true, null);
 
         // when
         EntryCodeResponse response = updateEntryCodeUseCase.execute(code, request);
@@ -140,7 +140,7 @@ class UpdateEntryCodeUseCaseTest {
         EntryCode entryCode = buildActiveEntryCode(code);
         given(entryCodeService.findByCode(code)).willReturn(entryCode);
 
-        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(null);
+        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(null, null);
 
         // when
         EntryCodeResponse response = updateEntryCodeUseCase.execute(code, request);
@@ -162,7 +162,7 @@ class UpdateEntryCodeUseCaseTest {
         given(entryCodeService.findByCode(unknownCode))
                 .willThrow(new RestApiException(AuthErrorStatus.INVALID_CODE));
 
-        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(false);
+        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(false, null);
 
         // when & then
         RestApiException ex = assertThrows(RestApiException.class,
@@ -194,7 +194,7 @@ class UpdateEntryCodeUseCaseTest {
                 .build();
         given(entryCodeService.findByCode(code)).willReturn(entryCode);
 
-        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(false);
+        UpdateEntryCodeRequest request = new UpdateEntryCodeRequest(false, null);
 
         // when
         EntryCodeResponse response = updateEntryCodeUseCase.execute(code, request);

--- a/src/test/java/com/yd/vibecode/domain/admin/ui/AdminEntryCodeControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/ui/AdminEntryCodeControllerTest.java
@@ -67,7 +67,7 @@ class AdminEntryCodeControllerTest {
         Long examId = 1L;
         Boolean isActive = true;
         EntryCodeResponse response = new EntryCodeResponse(
-            "CODE123", examId, 100L, "Test Label", LocalDateTime.now().plusDays(1), 10, 0, true
+            "CODE123", examId, 100L, "Test Label", LocalDateTime.now().plusDays(1), 10, 0, true, 20000
         );
 
         given(getEntryCodesUseCase.execute(eq(examId), eq(isActive)))

--- a/src/test/java/com/yd/vibecode/domain/auth/application/usecase/EnterUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/application/usecase/EnterUseCaseTest.java
@@ -110,6 +110,7 @@ class EnterUseCaseTest {
                 .code("CODE123")
                 .examId(1L)
                 .maxUses(10)
+                .tokenLimit(10000)
                 .build();
 
         User newParticipant = User.builder()

--- a/src/test/java/com/yd/vibecode/domain/auth/application/usecase/EnterUseCaseTokenLimitTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/application/usecase/EnterUseCaseTokenLimitTest.java
@@ -1,0 +1,376 @@
+package com.yd.vibecode.domain.auth.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.yd.vibecode.domain.auth.application.dto.request.EnterRequest;
+import com.yd.vibecode.domain.auth.application.dto.response.EnterResponse;
+import com.yd.vibecode.domain.auth.domain.entity.EntryCode;
+import com.yd.vibecode.domain.auth.domain.entity.User;
+import com.yd.vibecode.domain.auth.domain.service.EntryCodeService;
+import com.yd.vibecode.domain.auth.domain.service.UserService;
+import com.yd.vibecode.domain.exam.domain.entity.Exam;
+import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
+import com.yd.vibecode.domain.exam.domain.entity.ExamState;
+import com.yd.vibecode.domain.exam.domain.repository.ExamParticipantRepository;
+import com.yd.vibecode.domain.exam.domain.service.ExamParticipantService;
+import com.yd.vibecode.domain.exam.domain.service.ExamService;
+import com.yd.vibecode.domain.problem.domain.entity.Difficulty;
+import com.yd.vibecode.domain.problem.domain.entity.Problem;
+import com.yd.vibecode.domain.problem.domain.entity.ProblemStatus;
+import com.yd.vibecode.domain.problem.domain.service.ProblemService;
+import com.yd.vibecode.domain.problem.infrastructure.entity.ProblemSetItem;
+import com.yd.vibecode.domain.problem.infrastructure.repository.ProblemSetItemRepository;
+import com.yd.vibecode.global.security.TokenProvider;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * EnterUseCase 버그픽스 검증 테스트
+ *
+ * <p>버그: 대기 중에 입장 시 tokenLimit 이 항상 구버전 기본값(20000)으로 고정되던 문제
+ * <p>수정: EntryCode 에 tokenLimit 전용 필드를 두고, 신규 참가자 생성 시
+ *         entryCode.getTokenLimit() 값을 ExamParticipantService.create() 에 전달
+ */
+@ExtendWith(MockitoExtension.class)
+class EnterUseCaseTokenLimitTest {
+
+    @InjectMocks
+    private EnterUseCase enterUseCase;
+
+    @Mock
+    private EntryCodeService entryCodeService;
+    @Mock
+    private UserService userService;
+    @Mock
+    private ExamParticipantService examParticipantService;
+    @Mock
+    private ExamParticipantRepository examParticipantRepository;
+    @Mock
+    private TokenProvider tokenProvider;
+    @Mock
+    private ExamService examService;
+    @Mock
+    private ProblemSetItemRepository problemSetItemRepository;
+    @Mock
+    private ProblemService problemService;
+
+    // -------------------------------------------------------------------------
+    // 1. 신규 참가자 — entryCode.getTokenLimit() 이 그대로 전달되는지 검증
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("신규 참가자 입장 시 EntryCode의 tokenLimit(50000)이 ExamParticipant에 적용된다")
+    void enter_newParticipant_uses_entryCode_tokenLimit() {
+        // given
+        final int customTokenLimit = 50000;
+
+        EntryCode entryCode = EntryCode.builder()
+                .code("CODE-CUSTOM")
+                .examId(1L)
+                .tokenLimit(customTokenLimit)
+                .maxUses(0)
+                .build();
+
+        User newUser = User.builder()
+                .name("신규사용자")
+                .phone("010-0000-1111")
+                .build();
+        ReflectionTestUtils.setField(newUser, "id", 200L);
+
+        ExamParticipant created = ExamParticipant.builder()
+                .examId(1L)
+                .participantId(200L)
+                .tokenLimit(customTokenLimit)
+                .tokenUsed(0)
+                .build();
+        ReflectionTestUtils.setField(created, "id", 300L);
+
+        Exam exam = Exam.builder()
+                .title("테스트 시험")
+                .state(ExamState.WAITING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(2))
+                .build();
+        ReflectionTestUtils.setField(exam, "id", 1L);
+
+        given(entryCodeService.findByCode("CODE-CUSTOM")).willReturn(entryCode);
+        given(userService.findByPhone("010-0000-1111")).willReturn(null);
+        given(userService.create("신규사용자", "010-0000-1111")).willReturn(newUser);
+        given(examParticipantService.findByExamIdAndParticipantId(1L, 200L)).willReturn(null);
+        given(problemSetItemRepository.findByProblemSetId(null)).willReturn(Collections.emptyList());
+        // create() 가 customTokenLimit 으로 호출돼야 함
+        given(examParticipantService.create(eq(1L), eq(200L), eq(null), eq(customTokenLimit), eq(null)))
+                .willReturn(created);
+        given(tokenProvider.createAccessToken(anyString(), anyString())).willReturn("token");
+        given(examService.findById(1L)).willReturn(exam);
+
+        // when
+        EnterResponse response = enterUseCase.execute(new EnterRequest("CODE-CUSTOM", "신규사용자", "010-0000-1111"));
+
+        // then — 응답의 session.tokenLimit 이 EntryCode 의 값과 일치해야 한다
+        assertThat(response.session().tokenLimit()).isEqualTo(customTokenLimit);
+
+        // ExamParticipantService.create() 에 entryCode.getTokenLimit() 값이 전달됐는지 명시적으로 검증
+        verify(examParticipantService).create(eq(1L), eq(200L), eq(null), eq(customTokenLimit), eq(null));
+    }
+
+    @Test
+    @DisplayName("신규 참가자 입장 시 구버전 기본값(20000)이 아닌 EntryCode의 tokenLimit(100000)이 사용된다")
+    void enter_newParticipant_does_not_use_legacy_default_tokenLimit() {
+        // given — 구버전 기본값과 명확히 다른 값으로 설정
+        final int legacyDefault = 20000;
+        final int newTokenLimit = 100000;
+
+        assertThat(newTokenLimit).isNotEqualTo(legacyDefault); // 전제 조건 확인
+
+        EntryCode entryCode = EntryCode.builder()
+                .code("CODE-NEW")
+                .examId(2L)
+                .tokenLimit(newTokenLimit)
+                .maxUses(5)
+                .build();
+
+        User newUser = User.builder()
+                .name("홍길동")
+                .phone("010-1111-2222")
+                .build();
+        ReflectionTestUtils.setField(newUser, "id", 201L);
+
+        ExamParticipant created = ExamParticipant.builder()
+                .examId(2L)
+                .participantId(201L)
+                .tokenLimit(newTokenLimit)
+                .tokenUsed(0)
+                .build();
+        ReflectionTestUtils.setField(created, "id", 301L);
+
+        Exam exam = Exam.builder()
+                .title("고용량 시험")
+                .state(ExamState.WAITING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(3))
+                .build();
+        ReflectionTestUtils.setField(exam, "id", 2L);
+
+        given(entryCodeService.findByCode("CODE-NEW")).willReturn(entryCode);
+        given(userService.findByPhone("010-1111-2222")).willReturn(null);
+        given(userService.create("홍길동", "010-1111-2222")).willReturn(newUser);
+        given(examParticipantService.findByExamIdAndParticipantId(2L, 201L)).willReturn(null);
+        given(problemSetItemRepository.findByProblemSetId(null)).willReturn(Collections.emptyList());
+        given(examParticipantService.create(eq(2L), eq(201L), eq(null), eq(newTokenLimit), eq(null)))
+                .willReturn(created);
+        given(tokenProvider.createAccessToken(anyString(), anyString())).willReturn("token2");
+        given(examService.findById(2L)).willReturn(exam);
+
+        // when
+        EnterResponse response = enterUseCase.execute(new EnterRequest("CODE-NEW", "홍길동", "010-1111-2222"));
+
+        // then — 절대로 구버전 기본값(20000) 이 아니어야 한다
+        assertThat(response.session().tokenLimit())
+                .isNotEqualTo(legacyDefault)
+                .isEqualTo(newTokenLimit);
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. 신규 참가자 + 문제 세트 존재 — specId 와 tokenLimit 모두 EntryCode 기준
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("신규 참가자 입장 시 문제 currentSpecId와 EntryCode tokenLimit이 함께 전달된다")
+    void enter_newParticipant_with_problemSet_applies_specId_and_entryCode_tokenLimit() {
+        // given
+        final int customTokenLimit = 75000;
+        final long problemSetId = 10L;
+        final long problemId = 20L;
+        final long expectedSpecId = 30L;
+
+        EntryCode entryCode = EntryCode.builder()
+                .code("CODE-PS")
+                .examId(3L)
+                .problemSetId(problemSetId)
+                .tokenLimit(customTokenLimit)
+                .maxUses(0)
+                .build();
+
+        User newUser = User.builder()
+                .name("이영희")
+                .phone("010-3333-4444")
+                .build();
+        ReflectionTestUtils.setField(newUser, "id", 202L);
+
+        ProblemSetItem item = ProblemSetItem.builder()
+                .problemSetId(problemSetId)
+                .problemId(problemId)
+                .build();
+
+        Problem problem = Problem.builder()
+                .title("알고리즘 문제")
+                .difficulty(Difficulty.MEDIUM)
+                .status(ProblemStatus.PUBLISHED)
+                .currentSpecId(expectedSpecId)
+                .build();
+        ReflectionTestUtils.setField(problem, "id", problemId);
+
+        ExamParticipant created = ExamParticipant.builder()
+                .examId(3L)
+                .participantId(202L)
+                .specId(expectedSpecId)
+                .assignedProblemId(problemId)
+                .tokenLimit(customTokenLimit)
+                .tokenUsed(0)
+                .build();
+        ReflectionTestUtils.setField(created, "id", 302L);
+
+        Exam exam = Exam.builder()
+                .title("문제세트 시험")
+                .state(ExamState.WAITING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(2))
+                .build();
+        ReflectionTestUtils.setField(exam, "id", 3L);
+
+        given(entryCodeService.findByCode("CODE-PS")).willReturn(entryCode);
+        given(userService.findByPhone("010-3333-4444")).willReturn(null);
+        given(userService.create("이영희", "010-3333-4444")).willReturn(newUser);
+        given(examParticipantService.findByExamIdAndParticipantId(3L, 202L)).willReturn(null);
+        given(problemSetItemRepository.findByProblemSetId(problemSetId)).willReturn(List.of(item));
+        given(problemService.findById(problemId)).willReturn(problem);
+        // specId = expectedSpecId, tokenLimit = customTokenLimit (EntryCode 값)
+        given(examParticipantService.create(
+                eq(3L), eq(202L), eq(expectedSpecId), eq(customTokenLimit), eq(problemId)))
+                .willReturn(created);
+        given(tokenProvider.createAccessToken(anyString(), anyString())).willReturn("token3");
+        given(examService.findById(3L)).willReturn(exam);
+
+        // when
+        EnterResponse response = enterUseCase.execute(new EnterRequest("CODE-PS", "이영희", "010-3333-4444"));
+
+        // then
+        assertThat(response.session().tokenLimit()).isEqualTo(customTokenLimit);
+        verify(examParticipantService).create(
+                eq(3L), eq(202L), eq(expectedSpecId), eq(customTokenLimit), eq(problemId));
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. EntryCode.tokenLimit 기본값 20000 — 값 미지정 시 필드 기본값 사용
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("EntryCode tokenLimit 미설정 시 기본값(20000)이 유지된다")
+    void entryCode_tokenLimit_default_is_20000_when_not_specified() {
+        // given — tokenLimit 을 명시하지 않고 빌더 사용
+        EntryCode entryCode = EntryCode.builder()
+                .code("CODE-DEFAULT")
+                .examId(4L)
+                .maxUses(0)
+                .build();
+
+        // then
+        assertThat(entryCode.getTokenLimit()).isEqualTo(20000);
+    }
+
+    @Test
+    @DisplayName("EntryCode 빌더에서 tokenLimit 명시 시 해당 값이 저장된다")
+    void entryCode_tokenLimit_set_explicitly_is_stored_correctly() {
+        // given
+        EntryCode entryCode = EntryCode.builder()
+                .code("CODE-EXPLICIT")
+                .examId(5L)
+                .tokenLimit(80000)
+                .maxUses(0)
+                .build();
+
+        // then
+        assertThat(entryCode.getTokenLimit()).isEqualTo(80000);
+    }
+
+    @Test
+    @DisplayName("EntryCode.updateTokenLimit — 양수 값으로만 갱신된다")
+    void entryCode_updateTokenLimit_only_accepts_positive_value() {
+        // given
+        EntryCode entryCode = EntryCode.builder()
+                .code("CODE-UPD")
+                .examId(6L)
+                .tokenLimit(30000)
+                .maxUses(0)
+                .build();
+
+        // when — 유효한 값으로 갱신
+        entryCode.updateTokenLimit(60000);
+
+        // then
+        assertThat(entryCode.getTokenLimit()).isEqualTo(60000);
+
+        // when — 0 이하 값은 무시됨
+        entryCode.updateTokenLimit(0);
+        entryCode.updateTokenLimit(-1);
+
+        // then — 여전히 60000 유지
+        assertThat(entryCode.getTokenLimit()).isEqualTo(60000);
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. 기존 참가자 재입장 — tokenLimit 은 기존 ExamParticipant 값을 그대로 사용
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("기존 참가자 재입장 시 EntryCode tokenLimit과 관계없이 기존 세션 tokenLimit을 반환한다")
+    void enter_existingParticipant_returns_existing_tokenLimit() {
+        // given
+        final int entryCodeTokenLimit = 99000;
+        final int existingTokenLimit = 45000; // 기존 참가자 세션에 이미 설정된 값
+
+        EntryCode entryCode = EntryCode.builder()
+                .code("CODE-EXIST")
+                .examId(7L)
+                .tokenLimit(entryCodeTokenLimit)
+                .maxUses(0)
+                .build();
+
+        User existingUser = User.builder()
+                .name("김유저")
+                .phone("010-5555-6666")
+                .build();
+        ReflectionTestUtils.setField(existingUser, "id", 203L);
+
+        ExamParticipant existingParticipant = ExamParticipant.builder()
+                .examId(7L)
+                .participantId(203L)
+                .tokenLimit(existingTokenLimit)
+                .tokenUsed(1000)
+                .build();
+        ReflectionTestUtils.setField(existingParticipant, "id", 303L);
+
+        Exam exam = Exam.builder()
+                .title("재입장 시험")
+                .state(ExamState.WAITING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(1))
+                .build();
+        ReflectionTestUtils.setField(exam, "id", 7L);
+
+        given(entryCodeService.findByCode("CODE-EXIST")).willReturn(entryCode);
+        given(userService.findByPhone("010-5555-6666")).willReturn(existingUser);
+        given(examParticipantService.findByExamIdAndParticipantId(7L, 203L)).willReturn(existingParticipant);
+        given(tokenProvider.createAccessToken(anyString(), anyString())).willReturn("token-exist");
+        given(examService.findById(7L)).willReturn(exam);
+
+        // when
+        EnterResponse response = enterUseCase.execute(new EnterRequest("CODE-EXIST", "김유저", "010-5555-6666"));
+
+        // then — 기존 참가자는 새로 create() 하지 않으므로 기존 tokenLimit 이 반환됨
+        assertThat(response.session().tokenLimit()).isEqualTo(existingTokenLimit);
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/auth/ui/AuthControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/ui/AuthControllerTest.java
@@ -22,6 +22,7 @@ import com.yd.vibecode.domain.auth.application.usecase.AdminLogoutUseCase;
 import com.yd.vibecode.domain.auth.application.usecase.AdminSignupUseCase;
 import com.yd.vibecode.domain.auth.application.usecase.EnterUseCase;
 import com.yd.vibecode.domain.auth.application.usecase.MeUseCase;
+import com.yd.vibecode.domain.auth.domain.service.RefreshTokenService;
 import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
 import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
 import com.yd.vibecode.global.security.JwtProperties;
@@ -29,6 +30,7 @@ import com.yd.vibecode.global.security.TokenProvider;
 import com.yd.vibecode.global.util.CookieUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,6 +80,8 @@ class AuthControllerTest {
     private CookieUtils cookieUtils;
     @MockBean
     private JwtProperties jwtProperties;
+    @MockBean
+    private RefreshTokenService refreshTokenService;
     // WebMvcConfig 가 JwtBlacklistInterceptor, ExcludeBlacklistPathProperties 를 주입받으므로 필요
     @MockBean
     private JwtBlacklistInterceptor jwtBlacklistInterceptor;
@@ -88,6 +92,7 @@ class AuthControllerTest {
     void setUp() {
         // JwtProperties: accessToken 만료시간 설정
         given(jwtProperties.getAccessTokenExpirationPeriodDay()).willReturn(3_600_000L);
+        given(jwtProperties.getRefreshTokenExpirationPeriodDay()).willReturn(86_400_000L);
         // JwtBlacklistInterceptor: preHandle 기본값이 false → true로 설정해 컨트롤러에 요청이 도달하도록 함
         given(jwtBlacklistInterceptor.preHandle(
                 any(HttpServletRequest.class),
@@ -148,6 +153,8 @@ class AuthControllerTest {
         AdminLoginRequest request = new AdminLoginRequest("admin", "password");
         AdminLoginResponse response = new AdminLoginResponse("admin-token", "ADMIN", null);
         given(adminLoginUseCase.execute(any(AdminLoginRequest.class))).willReturn(response);
+        given(tokenProvider.getId("admin-token")).willReturn(Optional.of("1"));
+        given(tokenProvider.createRefreshToken("1")).willReturn("refresh-token");
 
         // when & then
         mockMvc.perform(post("/api/auth/admin/login")
@@ -161,6 +168,34 @@ class AuthControllerTest {
                 eq("admin-token"),
                 eq(3600)
         );
+        verify(refreshTokenService).saveRefreshToken(eq("1"), eq("refresh-token"), eq(Duration.ofMillis(86_400_000L)));
+        verify(cookieUtils).setRefreshTokenCookie(
+                any(HttpServletResponse.class),
+                eq("refresh-token"),
+                eq(86400)
+        );
+    }
+
+    @Test
+    @DisplayName("관리자 토큰 재발급 API — refresh token 검증 후 access/refresh 쿠키 재발급")
+    void admin_reissue_api_success() throws Exception {
+        // given
+        given(cookieUtils.getRefreshTokenFromRequest(any(HttpServletRequest.class))).willReturn("old-refresh");
+        given(tokenProvider.validateToken("old-refresh")).willReturn(true);
+        given(tokenProvider.getId("old-refresh")).willReturn(Optional.of("1"));
+        given(refreshTokenService.isExist("old-refresh", "1")).willReturn(true);
+        given(tokenProvider.createAccessToken("1", "ADMIN")).willReturn("new-access");
+        given(tokenProvider.createRefreshToken("1")).willReturn("new-refresh");
+        given(tokenProvider.getRemainingDuration("old-refresh")).willReturn(Optional.of(Duration.ofSeconds(120)));
+
+        // when & then
+        mockMvc.perform(post("/api/auth/admin/reissue"))
+                .andExpect(status().isOk());
+
+        verify(refreshTokenService).deleteRefreshToken("1");
+        verify(refreshTokenService).saveRefreshToken("1", "new-refresh", Duration.ofSeconds(120));
+        verify(cookieUtils).setAccessTokenCookie(any(HttpServletResponse.class), eq("new-access"), eq(3600));
+        verify(cookieUtils).setRefreshTokenCookie(any(HttpServletResponse.class), eq("new-refresh"), eq(120));
     }
 
     // =========================================================================
@@ -183,6 +218,7 @@ class AuthControllerTest {
 
         verify(adminLogoutUseCase).execute(token);
         verify(cookieUtils).clearAccessTokenCookie(any(HttpServletResponse.class));
+        verify(cookieUtils).clearRefreshTokenCookie(any(HttpServletResponse.class));
     }
 
     @Test

--- a/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetParticipantSessionUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetParticipantSessionUseCaseTest.java
@@ -65,7 +65,7 @@ class GetParticipantSessionUseCaseTest {
         ParticipantSessionResponse response = getParticipantSessionUseCase.execute(examId, participantId);
 
         // then
-        assertThat(response.participantId()).isEqualTo(999L);
+        assertThat(response.examParticipantId()).isEqualTo(999L);
         assertThat(response.examId()).isEqualTo(examId);
         assertThat(response.specId()).isEqualTo(specId);
         assertThat(response.assignedProblemId()).isEqualTo(assignedProblemId);
@@ -161,7 +161,7 @@ class GetParticipantSessionUseCaseTest {
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("참가자 세션 조회 실패 — 해당 시험에 참가자가 없으면 EXAM_NOT_FOUND 예외 발생")
+    @DisplayName("참가자 세션 조회 실패 — 해당 시험에 참가자가 없으면 PARTICIPANT_NOT_FOUND 예외 발생")
     void execute_throws_when_participant_not_found() {
         // given
         Long examId = 5L;
@@ -176,12 +176,12 @@ class GetParticipantSessionUseCaseTest {
                 .satisfies(ex -> {
                     RestApiException restEx = (RestApiException) ex;
                     assertThat(restEx.getErrorCode().getCode())
-                            .isEqualTo(ExamErrorStatus.EXAM_NOT_FOUND.getCode().getCode());
+                            .isEqualTo(ExamErrorStatus.PARTICIPANT_NOT_FOUND.getCode().getCode());
                 });
     }
 
     @Test
-    @DisplayName("참가자 세션 조회 실패 — 다른 시험 ID 로 조회하면 EXAM_NOT_FOUND 예외 발생")
+    @DisplayName("참가자 세션 조회 실패 — 다른 시험 ID 로 조회하면 PARTICIPANT_NOT_FOUND 예외 발생")
     void execute_throws_when_wrong_examId_is_provided() {
         // given — participantId 는 존재하지만 examId 가 다른 경우
         Long wrongExamId = 99L;
@@ -196,7 +196,7 @@ class GetParticipantSessionUseCaseTest {
                 .satisfies(ex -> {
                     RestApiException restEx = (RestApiException) ex;
                     assertThat(restEx.getErrorCode().getCode())
-                            .isEqualTo(ExamErrorStatus.EXAM_NOT_FOUND.getCode().getCode());
+                            .isEqualTo(ExamErrorStatus.PARTICIPANT_NOT_FOUND.getCode().getCode());
                 });
     }
 
@@ -222,7 +222,7 @@ class GetParticipantSessionUseCaseTest {
         ParticipantSessionResponse response = ParticipantSessionResponse.from(participant);
 
         // then
-        assertThat(response.participantId()).isEqualTo(50L);
+        assertThat(response.examParticipantId()).isEqualTo(50L);
         assertThat(response.examId()).isEqualTo(10L);
         assertThat(response.specId()).isEqualTo(30L);
         assertThat(response.assignedProblemId()).isEqualTo(40L);

--- a/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetParticipantSessionUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetParticipantSessionUseCaseTest.java
@@ -1,0 +1,232 @@
+package com.yd.vibecode.domain.exam.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.yd.vibecode.domain.exam.application.dto.response.ParticipantSessionResponse;
+import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
+import com.yd.vibecode.domain.exam.domain.service.ExamParticipantService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.ExamErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * GetParticipantSessionUseCase 테스트
+ *
+ * <p>신규 엔드포인트 GET /api/exams/{examId}/participants/me 에 대한 검증
+ * <p>버그픽스: 시험 시작 후 최신 specId / tokenLimit 을 프론트에서 즉시 폴링할 수 있도록
+ *           참가자 세션 조회 엔드포인트 추가
+ */
+@ExtendWith(MockitoExtension.class)
+class GetParticipantSessionUseCaseTest {
+
+    @InjectMocks
+    private GetParticipantSessionUseCase getParticipantSessionUseCase;
+
+    @Mock
+    private ExamParticipantService examParticipantService;
+
+    // -------------------------------------------------------------------------
+    // 1. 조회 성공 — 정상 참가자
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("참가자 세션 조회 성공 — 모든 필드가 올바르게 매핑된다")
+    void execute_success_returns_correct_session_fields() {
+        // given
+        Long examId = 1L;
+        Long participantId = 100L;
+        Long specId = 200L;
+        Long assignedProblemId = 300L;
+        final int tokenLimit = 50000;
+        final int tokenUsed = 1234;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(participantId)
+                .specId(specId)
+                .assignedProblemId(assignedProblemId)
+                .tokenLimit(tokenLimit)
+                .tokenUsed(tokenUsed)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 999L);
+
+        given(examParticipantService.findByExamIdAndParticipantId(examId, participantId))
+                .willReturn(participant);
+
+        // when
+        ParticipantSessionResponse response = getParticipantSessionUseCase.execute(examId, participantId);
+
+        // then
+        assertThat(response.participantId()).isEqualTo(999L);
+        assertThat(response.examId()).isEqualTo(examId);
+        assertThat(response.specId()).isEqualTo(specId);
+        assertThat(response.assignedProblemId()).isEqualTo(assignedProblemId);
+        assertThat(response.tokenLimit()).isEqualTo(tokenLimit);
+        assertThat(response.tokenUsed()).isEqualTo(tokenUsed);
+    }
+
+    @Test
+    @DisplayName("참가자 세션 조회 성공 — 시험 시작 후 동기화된 specId가 반영된다")
+    void execute_success_returns_synced_specId_after_exam_start() {
+        // given — StartExamUseCase 의 syncParticipants() 가 이미 실행된 상황 시뮬레이션
+        Long examId = 2L;
+        Long participantId = 101L;
+        Long syncedSpecId = 500L;  // 시험 시작 시 동기화된 최신 specId
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(participantId)
+                .specId(syncedSpecId)
+                .tokenLimit(60000)
+                .tokenUsed(0)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 1001L);
+
+        given(examParticipantService.findByExamIdAndParticipantId(examId, participantId))
+                .willReturn(participant);
+
+        // when
+        ParticipantSessionResponse response = getParticipantSessionUseCase.execute(examId, participantId);
+
+        // then — 동기화된 specId 가 응답에 포함되어야 한다
+        assertThat(response.specId()).isEqualTo(syncedSpecId);
+        assertThat(response.tokenLimit()).isEqualTo(60000);
+    }
+
+    @Test
+    @DisplayName("참가자 세션 조회 성공 — specId 미설정 상태도 null 로 정상 반환된다")
+    void execute_success_when_specId_is_null() {
+        // given — 문제 미배정 참가자
+        Long examId = 3L;
+        Long participantId = 102L;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(participantId)
+                .specId(null)
+                .assignedProblemId(null)
+                .tokenLimit(20000)
+                .tokenUsed(0)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 1002L);
+
+        given(examParticipantService.findByExamIdAndParticipantId(examId, participantId))
+                .willReturn(participant);
+
+        // when
+        ParticipantSessionResponse response = getParticipantSessionUseCase.execute(examId, participantId);
+
+        // then
+        assertThat(response.specId()).isNull();
+        assertThat(response.assignedProblemId()).isNull();
+        assertThat(response.tokenLimit()).isEqualTo(20000);
+    }
+
+    @Test
+    @DisplayName("참가자 세션 조회 성공 — tokenUsed 가 0인 초기 상태도 정상 반환된다")
+    void execute_success_initial_state_token_used_is_zero() {
+        // given
+        Long examId = 4L;
+        Long participantId = 103L;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(participantId)
+                .tokenLimit(40000)
+                .tokenUsed(0)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 1003L);
+
+        given(examParticipantService.findByExamIdAndParticipantId(examId, participantId))
+                .willReturn(participant);
+
+        // when
+        ParticipantSessionResponse response = getParticipantSessionUseCase.execute(examId, participantId);
+
+        // then
+        assertThat(response.tokenUsed()).isZero();
+        assertThat(response.tokenLimit()).isEqualTo(40000);
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. 조회 실패 — 참가자가 해당 시험에 등록되지 않은 경우
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("참가자 세션 조회 실패 — 해당 시험에 참가자가 없으면 EXAM_NOT_FOUND 예외 발생")
+    void execute_throws_when_participant_not_found() {
+        // given
+        Long examId = 5L;
+        Long participantId = 999L; // 존재하지 않는 참가자
+
+        given(examParticipantService.findByExamIdAndParticipantId(examId, participantId))
+                .willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> getParticipantSessionUseCase.execute(examId, participantId))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> {
+                    RestApiException restEx = (RestApiException) ex;
+                    assertThat(restEx.getErrorCode().getCode())
+                            .isEqualTo(ExamErrorStatus.EXAM_NOT_FOUND.getCode().getCode());
+                });
+    }
+
+    @Test
+    @DisplayName("참가자 세션 조회 실패 — 다른 시험 ID 로 조회하면 EXAM_NOT_FOUND 예외 발생")
+    void execute_throws_when_wrong_examId_is_provided() {
+        // given — participantId 는 존재하지만 examId 가 다른 경우
+        Long wrongExamId = 99L;
+        Long participantId = 100L;
+
+        given(examParticipantService.findByExamIdAndParticipantId(wrongExamId, participantId))
+                .willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> getParticipantSessionUseCase.execute(wrongExamId, participantId))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> {
+                    RestApiException restEx = (RestApiException) ex;
+                    assertThat(restEx.getErrorCode().getCode())
+                            .isEqualTo(ExamErrorStatus.EXAM_NOT_FOUND.getCode().getCode());
+                });
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. ParticipantSessionResponse.from() 매핑 단위 검증
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("ParticipantSessionResponse.from() — ExamParticipant 의 모든 필드가 정확히 매핑된다")
+    void participantSessionResponse_from_maps_all_fields() {
+        // given
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(10L)
+                .participantId(20L)
+                .specId(30L)
+                .assignedProblemId(40L)
+                .tokenLimit(55000)
+                .tokenUsed(5000)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 50L);
+
+        // when
+        ParticipantSessionResponse response = ParticipantSessionResponse.from(participant);
+
+        // then
+        assertThat(response.participantId()).isEqualTo(50L);
+        assertThat(response.examId()).isEqualTo(10L);
+        assertThat(response.specId()).isEqualTo(30L);
+        assertThat(response.assignedProblemId()).isEqualTo(40L);
+        assertThat(response.tokenLimit()).isEqualTo(55000);
+        assertThat(response.tokenUsed()).isEqualTo(5000);
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/exam/application/usecase/StartExamSyncTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/application/usecase/StartExamSyncTest.java
@@ -1,0 +1,455 @@
+package com.yd.vibecode.domain.exam.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.yd.vibecode.domain.auth.domain.entity.EntryCode;
+import com.yd.vibecode.domain.auth.domain.repository.EntryCodeRepository;
+import com.yd.vibecode.domain.exam.application.dto.event.ExamStateEvent;
+import com.yd.vibecode.domain.exam.domain.entity.Exam;
+import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
+import com.yd.vibecode.domain.exam.domain.entity.ExamState;
+import com.yd.vibecode.domain.exam.domain.repository.ExamParticipantRepository;
+import com.yd.vibecode.domain.exam.domain.service.ExamService;
+import com.yd.vibecode.domain.problem.domain.entity.Difficulty;
+import com.yd.vibecode.domain.problem.domain.entity.Problem;
+import com.yd.vibecode.domain.problem.domain.entity.ProblemStatus;
+import com.yd.vibecode.domain.problem.domain.repository.ProblemRepository;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * StartExamUseCase 버그픽스 검증 테스트
+ *
+ * <p>버그: 시험 시작 시 대기 중이던 참가자에게 구버전 specId(null)와 tokenLimit(20000)으로
+ *         시험이 시작되던 문제
+ * <p>수정: execute() 내부에서 먼저 syncParticipants() 를 호출하여
+ *         모든 참가자의 specId 와 tokenLimit 을 최신 값으로 갱신한 뒤 상태를 RUNNING 으로 전환
+ */
+@ExtendWith(MockitoExtension.class)
+class StartExamSyncTest {
+
+    @InjectMocks
+    private StartExamUseCase startExamUseCase;
+
+    @Mock
+    private ExamService examService;
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+    @Mock
+    private ExamParticipantRepository examParticipantRepository;
+    @Mock
+    private ProblemRepository problemRepository;
+    @Mock
+    private EntryCodeRepository entryCodeRepository;
+
+    // -------------------------------------------------------------------------
+    // 1. specId 동기화 — 참가자의 specId 가 문제의 currentSpecId 로 갱신되는지 확인
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("시험 시작 시 참가자의 specId가 문제의 currentSpecId로 동기화된다")
+    void execute_syncs_specId_to_current_spec_id_of_problem() {
+        // given
+        Long examId = 1L;
+        Long problemId = 10L;
+        Long outdatedSpecId = 100L;
+        Long latestSpecId = 200L;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(1L)
+                .assignedProblemId(problemId)
+                .specId(outdatedSpecId)  // 구버전 specId
+                .tokenLimit(20000)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 1L);
+
+        Problem problem = Problem.builder()
+                .title("문제 A")
+                .difficulty(Difficulty.MEDIUM)
+                .status(ProblemStatus.PUBLISHED)
+                .currentSpecId(latestSpecId)
+                .build();
+        ReflectionTestUtils.setField(problem, "id", problemId);
+
+        Exam exam = Exam.builder()
+                .title("테스트 시험")
+                .state(ExamState.RUNNING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(2))
+                .version(1)
+                .createdBy(1L)
+                .build();
+
+        given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
+        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(Collections.emptyList());
+        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
+        given(examService.startExam(examId)).willReturn(exam);
+
+        // when
+        startExamUseCase.execute(examId);
+
+        // then — participant.specId 가 최신 값으로 업데이트됐어야 함
+        assertThat(participant.getSpecId()).isEqualTo(latestSpecId);
+        verify(examService).startExam(examId);
+        verify(messagingTemplate).convertAndSend(eq("/topic/exam/" + examId), any(ExamStateEvent.class));
+    }
+
+    @Test
+    @DisplayName("시험 시작 시 참가자의 specId가 이미 최신이면 updateSpecId가 호출되지 않는다")
+    void execute_does_not_update_specId_when_already_current() {
+        // given
+        Long examId = 2L;
+        Long problemId = 11L;
+        Long currentSpecId = 201L;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(2L)
+                .assignedProblemId(problemId)
+                .specId(currentSpecId)  // 이미 최신 specId
+                .tokenLimit(20000)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 2L);
+
+        Problem problem = Problem.builder()
+                .title("문제 B")
+                .difficulty(Difficulty.EASY)
+                .status(ProblemStatus.PUBLISHED)
+                .currentSpecId(currentSpecId)
+                .build();
+        ReflectionTestUtils.setField(problem, "id", problemId);
+
+        Exam exam = Exam.builder()
+                .title("시험 2")
+                .state(ExamState.RUNNING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(1))
+                .version(1)
+                .createdBy(1L)
+                .build();
+
+        given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
+        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(Collections.emptyList());
+        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
+        given(examService.startExam(examId)).willReturn(exam);
+
+        // when
+        startExamUseCase.execute(examId);
+
+        // then — specId 값이 변경되지 않아야 함
+        assertThat(participant.getSpecId()).isEqualTo(currentSpecId);
+    }
+
+    @Test
+    @DisplayName("시험 시작 시 참가자에게 assignedProblemId가 없으면 specId 동기화를 건너뛴다")
+    void execute_skips_specId_sync_when_no_assigned_problem() {
+        // given
+        Long examId = 3L;
+
+        // assignedProblemId = null 인 참가자
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(3L)
+                .assignedProblemId(null)
+                .specId(null)
+                .tokenLimit(20000)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 3L);
+
+        Exam exam = Exam.builder()
+                .title("시험 3")
+                .state(ExamState.RUNNING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(1))
+                .version(1)
+                .createdBy(1L)
+                .build();
+
+        given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
+        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(Collections.emptyList());
+        given(examService.startExam(examId)).willReturn(exam);
+
+        // when
+        startExamUseCase.execute(examId);
+
+        // then — problemRepository 조회가 전혀 발생하지 않아야 함
+        verify(problemRepository, never()).findById(any());
+        assertThat(participant.getSpecId()).isNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. tokenLimit 동기화 — 활성 EntryCode 의 tokenLimit 이 참가자에게 적용되는지 확인
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("시험 시작 시 활성 EntryCode의 tokenLimit으로 참가자 tokenLimit이 동기화된다")
+    void execute_syncs_tokenLimit_from_active_entry_code() {
+        // given
+        Long examId = 4L;
+        final int updatedTokenLimit = 50000;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(4L)
+                .assignedProblemId(null)
+                .tokenLimit(20000)  // 구버전 기본값
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 4L);
+
+        EntryCode activeCode = EntryCode.builder()
+                .code("CODE-ACTIVE")
+                .examId(examId)
+                .tokenLimit(updatedTokenLimit)
+                .maxUses(0)
+                .isActive(true)
+                .build();
+
+        Exam exam = Exam.builder()
+                .title("시험 4")
+                .state(ExamState.RUNNING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(2))
+                .version(1)
+                .createdBy(1L)
+                .build();
+
+        given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
+        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(List.of(activeCode));
+        given(examService.startExam(examId)).willReturn(exam);
+
+        // when
+        startExamUseCase.execute(examId);
+
+        // then — 참가자의 tokenLimit 이 EntryCode 값으로 갱신됐어야 함
+        assertThat(participant.getTokenLimit()).isEqualTo(updatedTokenLimit);
+    }
+
+    @Test
+    @DisplayName("시험 시작 시 활성 EntryCode가 없으면 참가자 tokenLimit을 변경하지 않는다")
+    void execute_does_not_change_tokenLimit_when_no_active_entry_code() {
+        // given
+        Long examId = 5L;
+        final int originalTokenLimit = 30000;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(5L)
+                .tokenLimit(originalTokenLimit)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 5L);
+
+        Exam exam = Exam.builder()
+                .title("시험 5")
+                .state(ExamState.RUNNING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(1))
+                .version(1)
+                .createdBy(1L)
+                .build();
+
+        given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
+        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(Collections.emptyList());
+        given(examService.startExam(examId)).willReturn(exam);
+
+        // when
+        startExamUseCase.execute(examId);
+
+        // then — tokenLimit 이 원래 값 그대로 유지돼야 함
+        assertThat(participant.getTokenLimit()).isEqualTo(originalTokenLimit);
+    }
+
+    @Test
+    @DisplayName("시험 시작 시 참가자 tokenLimit이 이미 EntryCode 값과 같으면 변경하지 않는다")
+    void execute_does_not_update_tokenLimit_when_already_same_as_entry_code() {
+        // given
+        Long examId = 6L;
+        final int sameTokenLimit = 50000;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(6L)
+                .tokenLimit(sameTokenLimit)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 6L);
+
+        EntryCode activeCode = EntryCode.builder()
+                .code("CODE-SAME")
+                .examId(examId)
+                .tokenLimit(sameTokenLimit)
+                .isActive(true)
+                .maxUses(0)
+                .build();
+
+        Exam exam = Exam.builder()
+                .title("시험 6")
+                .state(ExamState.RUNNING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(1))
+                .version(1)
+                .createdBy(1L)
+                .build();
+
+        given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
+        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(List.of(activeCode));
+        given(examService.startExam(examId)).willReturn(exam);
+
+        // when
+        startExamUseCase.execute(examId);
+
+        // then — 동일 값이므로 tokenLimit 이 변하지 않아야 함
+        assertThat(participant.getTokenLimit()).isEqualTo(sameTokenLimit);
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. 복합 시나리오 — specId + tokenLimit 동시 동기화
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("시험 시작 시 specId와 tokenLimit이 동시에 동기화된다")
+    void execute_syncs_both_specId_and_tokenLimit_simultaneously() {
+        // given
+        Long examId = 7L;
+        Long problemId = 12L;
+        Long newSpecId = 300L;
+        final int newTokenLimit = 60000;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(7L)
+                .assignedProblemId(problemId)
+                .specId(null)       // 구버전 — specId 미설정
+                .tokenLimit(20000)  // 구버전 기본값
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 7L);
+
+        Problem problem = Problem.builder()
+                .title("문제 C")
+                .difficulty(Difficulty.HARD)
+                .status(ProblemStatus.PUBLISHED)
+                .currentSpecId(newSpecId)
+                .build();
+        ReflectionTestUtils.setField(problem, "id", problemId);
+
+        EntryCode activeCode = EntryCode.builder()
+                .code("CODE-COMBO")
+                .examId(examId)
+                .tokenLimit(newTokenLimit)
+                .isActive(true)
+                .maxUses(0)
+                .build();
+
+        Exam exam = Exam.builder()
+                .title("복합 시험")
+                .state(ExamState.RUNNING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(3))
+                .version(1)
+                .createdBy(1L)
+                .build();
+
+        given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
+        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(List.of(activeCode));
+        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
+        given(examService.startExam(examId)).willReturn(exam);
+
+        // when
+        startExamUseCase.execute(examId);
+
+        // then — 두 값 모두 갱신됨
+        assertThat(participant.getSpecId()).isEqualTo(newSpecId);
+        assertThat(participant.getTokenLimit()).isEqualTo(newTokenLimit);
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. 엣지 케이스 — 참가자가 없을 때 syncParticipants 가 조용히 종료된다
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("시험에 참가자가 없어도 시험 시작이 정상적으로 완료된다")
+    void execute_succeeds_when_no_participants() {
+        // given
+        Long examId = 8L;
+
+        Exam exam = Exam.builder()
+                .title("빈 시험")
+                .state(ExamState.RUNNING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(1))
+                .version(1)
+                .createdBy(1L)
+                .build();
+
+        given(examParticipantRepository.findByExamId(examId)).willReturn(Collections.emptyList());
+        given(examService.startExam(examId)).willReturn(exam);
+
+        // when
+        startExamUseCase.execute(examId);
+
+        // then — EntryCode 조회 없이도 시험 시작 및 WS 브로드캐스트가 이루어져야 함
+        verify(entryCodeRepository, never()).findByExamIdAndIsActive(any(), any());
+        verify(examService).startExam(examId);
+        verify(messagingTemplate).convertAndSend(eq("/topic/exam/" + examId), any(ExamStateEvent.class));
+    }
+
+    @Test
+    @DisplayName("여러 참가자가 있을 때 모든 참가자의 specId가 동기화된다")
+    void execute_syncs_specId_for_all_participants() {
+        // given
+        Long examId = 9L;
+        Long problemId = 13L;
+        Long latestSpecId = 400L;
+
+        ExamParticipant participant1 = ExamParticipant.builder()
+                .examId(examId).participantId(10L)
+                .assignedProblemId(problemId).specId(1L).tokenLimit(20000).build();
+        ReflectionTestUtils.setField(participant1, "id", 10L);
+
+        ExamParticipant participant2 = ExamParticipant.builder()
+                .examId(examId).participantId(11L)
+                .assignedProblemId(problemId).specId(2L).tokenLimit(20000).build();
+        ReflectionTestUtils.setField(participant2, "id", 11L);
+
+        Problem problem = Problem.builder()
+                .title("문제 D")
+                .difficulty(Difficulty.EASY)
+                .status(ProblemStatus.PUBLISHED)
+                .currentSpecId(latestSpecId)
+                .build();
+        ReflectionTestUtils.setField(problem, "id", problemId);
+
+        Exam exam = Exam.builder()
+                .title("다중 참가 시험")
+                .state(ExamState.RUNNING)
+                .startsAt(LocalDateTime.now())
+                .endsAt(LocalDateTime.now().plusHours(1))
+                .version(1).createdBy(1L).build();
+
+        given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant1, participant2));
+        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(Collections.emptyList());
+        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
+        given(examService.startExam(examId)).willReturn(exam);
+
+        // when
+        startExamUseCase.execute(examId);
+
+        // then — 두 참가자 모두 최신 specId 로 갱신됐어야 함
+        assertThat(participant1.getSpecId()).isEqualTo(latestSpecId);
+        assertThat(participant2.getSpecId()).isEqualTo(latestSpecId);
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/exam/application/usecase/StartExamSyncTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/application/usecase/StartExamSyncTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.yd.vibecode.domain.auth.domain.entity.EntryCode;
 import com.yd.vibecode.domain.auth.domain.repository.EntryCodeRepository;
@@ -23,6 +24,7 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -97,8 +99,8 @@ class StartExamSyncTest {
                 .build();
 
         given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
-        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(Collections.emptyList());
-        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
+        given(entryCodeRepository.findTopByExamIdAndIsActiveOrderByCreatedAtDesc(examId, true)).willReturn(Optional.empty());
+        given(problemRepository.findAllById(Set.of(problemId))).willReturn(List.of(problem));
         given(examService.startExam(examId)).willReturn(exam);
 
         // when
@@ -145,8 +147,8 @@ class StartExamSyncTest {
                 .build();
 
         given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
-        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(Collections.emptyList());
-        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
+        given(entryCodeRepository.findTopByExamIdAndIsActiveOrderByCreatedAtDesc(examId, true)).willReturn(Optional.empty());
+        given(problemRepository.findAllById(Set.of(problemId))).willReturn(List.of(problem));
         given(examService.startExam(examId)).willReturn(exam);
 
         // when
@@ -182,14 +184,14 @@ class StartExamSyncTest {
                 .build();
 
         given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
-        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(Collections.emptyList());
+        given(entryCodeRepository.findTopByExamIdAndIsActiveOrderByCreatedAtDesc(examId, true)).willReturn(Optional.empty());
         given(examService.startExam(examId)).willReturn(exam);
 
         // when
         startExamUseCase.execute(examId);
 
         // then — problemRepository 조회가 전혀 발생하지 않아야 함
-        verify(problemRepository, never()).findById(any());
+        verifyNoInteractions(problemRepository);
         assertThat(participant.getSpecId()).isNull();
     }
 
@@ -230,7 +232,7 @@ class StartExamSyncTest {
                 .build();
 
         given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
-        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(List.of(activeCode));
+        given(entryCodeRepository.findTopByExamIdAndIsActiveOrderByCreatedAtDesc(examId, true)).willReturn(Optional.of(activeCode));
         given(examService.startExam(examId)).willReturn(exam);
 
         // when
@@ -264,7 +266,7 @@ class StartExamSyncTest {
                 .build();
 
         given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
-        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(Collections.emptyList());
+        given(entryCodeRepository.findTopByExamIdAndIsActiveOrderByCreatedAtDesc(examId, true)).willReturn(Optional.empty());
         given(examService.startExam(examId)).willReturn(exam);
 
         // when
@@ -306,7 +308,7 @@ class StartExamSyncTest {
                 .build();
 
         given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
-        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(List.of(activeCode));
+        given(entryCodeRepository.findTopByExamIdAndIsActiveOrderByCreatedAtDesc(examId, true)).willReturn(Optional.of(activeCode));
         given(examService.startExam(examId)).willReturn(exam);
 
         // when
@@ -364,8 +366,8 @@ class StartExamSyncTest {
                 .build();
 
         given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant));
-        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(List.of(activeCode));
-        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
+        given(entryCodeRepository.findTopByExamIdAndIsActiveOrderByCreatedAtDesc(examId, true)).willReturn(Optional.of(activeCode));
+        given(problemRepository.findAllById(Set.of(problemId))).willReturn(List.of(problem));
         given(examService.startExam(examId)).willReturn(exam);
 
         // when
@@ -441,8 +443,8 @@ class StartExamSyncTest {
                 .version(1).createdBy(1L).build();
 
         given(examParticipantRepository.findByExamId(examId)).willReturn(List.of(participant1, participant2));
-        given(entryCodeRepository.findByExamIdAndIsActive(examId, true)).willReturn(Collections.emptyList());
-        given(problemRepository.findById(problemId)).willReturn(Optional.of(problem));
+        given(entryCodeRepository.findTopByExamIdAndIsActiveOrderByCreatedAtDesc(examId, true)).willReturn(Optional.empty());
+        given(problemRepository.findAllById(Set.of(problemId))).willReturn(List.of(problem));
         given(examService.startExam(examId)).willReturn(exam);
 
         // when

--- a/src/test/java/com/yd/vibecode/domain/exam/application/usecase/StartExamUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/application/usecase/StartExamUseCaseTest.java
@@ -12,12 +12,16 @@ import static org.mockito.Mockito.verify;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
+import com.yd.vibecode.domain.auth.domain.repository.EntryCodeRepository;
 import com.yd.vibecode.domain.exam.application.dto.event.ExamStateEvent;
 import com.yd.vibecode.domain.exam.domain.entity.Exam;
 import com.yd.vibecode.domain.exam.domain.entity.ExamState;
+import com.yd.vibecode.domain.exam.domain.repository.ExamParticipantRepository;
 import com.yd.vibecode.domain.exam.domain.service.ExamService;
+import com.yd.vibecode.domain.problem.domain.repository.ProblemRepository;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 
 @ExtendWith(MockitoExtension.class)
 class StartExamUseCaseTest {
@@ -30,6 +34,12 @@ class StartExamUseCaseTest {
 
     @Mock
     private SimpMessagingTemplate messagingTemplate;
+    @Mock
+    private ExamParticipantRepository examParticipantRepository;
+    @Mock
+    private ProblemRepository problemRepository;
+    @Mock
+    private EntryCodeRepository entryCodeRepository;
 
     @Test
     @DisplayName("시험 시작 UseCase 성공: 서비스 호출 및 WS 브로드캐스트 확인")
@@ -46,6 +56,7 @@ class StartExamUseCaseTest {
                 .build();
 
         given(examService.startExam(examId)).willReturn(exam);
+        given(examParticipantRepository.findByExamId(examId)).willReturn(Collections.emptyList());
 
         // when
         startExamUseCase.execute(examId);

--- a/src/test/java/com/yd/vibecode/global/security/TokenProviderTest.java
+++ b/src/test/java/com/yd/vibecode/global/security/TokenProviderTest.java
@@ -1,0 +1,28 @@
+package com.yd.vibecode.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TokenProviderTest {
+
+    @Test
+    @DisplayName("refresh token은 같은 초에 연속 발급해도 서로 달라야 한다")
+    void create_refresh_token_generates_unique_token() {
+        TokenProvider tokenProvider = new TokenProvider(jwtProperties());
+
+        String first = tokenProvider.createRefreshToken("1");
+        String second = tokenProvider.createRefreshToken("1");
+
+        assertThat(second).isNotEqualTo(first);
+    }
+
+    private JwtProperties jwtProperties() {
+        JwtProperties props = new JwtProperties();
+        props.setKey("test-secret-key-32-characters-long!!");
+        props.setAccessTokenExpirationPeriodDay(3_600_000L);
+        props.setRefreshTokenExpirationPeriodDay(86_400_000L);
+        return props;
+    }
+}


### PR DESCRIPTION
## 개요

대기 중 입장한 참가자가 시험 시작 후 구버전 데이터(tokenLimit, specId)로 진입하는 버그를 수정합니다.

## 배경 / 원인

ExamParticipant는 enterExam 시점에 tokenLimit과 specId를 스냅샷으로 저장합니다.
관리자가 시험 시작 전 tokenLimit이나 문제 스펙을 변경해도, 이미 대기 중인 참가자에게는
변경값이 반영되지 않아 다음 증상이 발생했습니다.

- AI 어시스턴트가 spec_id = null로 호출되어 오동작
- tokenLimit이 100,000이어야 하는데 20,000(이전 값)으로 시험 진행

## 변경 사항

### EntryCode tokenLimit 필드 분리 (`BUG-2`)

- `EntryCode`: `tokenLimit` 컬럼 추가 (기존 `maxUses * 1000` 계산 방식 제거)
- `CreateEntryCodeRequest` / `UpdateEntryCodeRequest`: `tokenLimit` 필드 추가
- `UpdateEntryCodeUseCase`: `entryCode.updateTokenLimit()` 호출 추가
- `EntryCodeResponse`: `tokenLimit` 응답에 포함
- `EnterUseCase`: `entryCode.getTokenLimit()` 으로 교체

### 시험 시작 시 참가자 동기화 (`#BUG-1`)

- `StartExamUseCase`: 시험 상태 변경 전 전체 참가자 specId·tokenLimit 일괄 동기화
  - 문제 조회를 `findAllById()` IN 쿼리 1회로 처리하여 N+1 방지
- `ExamParticipant`: `updateTokenLimit()` 메서드 추가
- `ExamParticipantService`: `syncSpecIdForExam()` 메서드 추가

### 참가자 세션 조회 엔드포인트 (`#BUG-1`)

- `ParticipantSessionResponse`: 신규 DTO (participantId, examId, tokenLimit, tokenUsed, specId, assignedProblemId)
- `GetParticipantSessionUseCase`: 신규 UseCase
- `ExamController`: `GET /api/exams/{examId}/participants/me` 엔드포인트 추가
- `ExamErrorStatus`: `PARTICIPANT_NOT_FOUND (EXAM007, 404)` 추가

### 테스트

| 파일 | 케이스 수 |
|---|---|
| `EnterUseCaseTokenLimitTest` | 7 |
| `StartExamSyncTest` | 9 |
| `GetParticipantSessionUseCaseTest` | 7 |

## 관련 이슈

closes #46

## 체크리스트

- [x] 의존성 방향 준수 (ui → application → domain ← infra)
- [x] 트랜잭션이 UseCase에만 존재
- [x] 에러 처리 `RestApiException + ExamErrorStatus`
- [x] DTO Record 타입 사용
- [x] N+1 쿼리 없음 (IN 쿼리로 일괄 조회)
- [x] 단위 테스트 추가 (23 케이스)