### PR TITLE
[FEAT] 활성 시험 세션 조회 API 구현 및 WebSocket 쿠키 인증 처리

### DIFF
--- a/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ActiveSessionResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ActiveSessionResponse.java
@@ -1,0 +1,35 @@
+package com.yd.vibecode.domain.exam.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.yd.vibecode.domain.exam.domain.entity.Exam;
+import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
+import com.yd.vibecode.domain.exam.domain.entity.ExamState;
+
+public record ActiveSessionResponse(
+    Long examId,
+    Long examParticipantId,
+    Long assignedProblemId,
+    Long specId,
+    ExamState examState,
+    LocalDateTime startsAt,
+    LocalDateTime endsAt,
+    LocalDateTime serverTime,
+    Integer tokenLimit,
+    Integer tokenUsed
+) {
+    public static ActiveSessionResponse from(Exam exam, ExamParticipant participant) {
+        return new ActiveSessionResponse(
+            exam.getId(),
+            participant.getId(),
+            participant.getAssignedProblemId(),
+            participant.getSpecId(),
+            exam.getState(),
+            exam.getStartsAt(),
+            exam.getEndsAt(),
+            LocalDateTime.now(),
+            participant.getTokenLimit(),
+            participant.getTokenUsed()
+        );
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCase.java
@@ -1,0 +1,37 @@
+package com.yd.vibecode.domain.exam.application.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.yd.vibecode.domain.exam.application.dto.response.ActiveSessionResponse;
+import com.yd.vibecode.domain.exam.domain.entity.Exam;
+import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
+import com.yd.vibecode.domain.exam.domain.service.ExamParticipantService;
+import com.yd.vibecode.domain.exam.domain.service.ExamService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.ExamErrorStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GetActiveSessionUseCase {
+
+    private final ExamParticipantService examParticipantService;
+    private final ExamService examService;
+
+    @Transactional(readOnly = true)
+    public ActiveSessionResponse execute(Long participantId) {
+        ExamParticipant participant = examParticipantService.findLatestByParticipantId(participantId);
+        if (participant == null) {
+            throw new RestApiException(ExamErrorStatus.NO_ACTIVE_SESSION);
+        }
+
+        Exam exam = examService.findById(participant.getExamId());
+        if (!exam.isRunning()) {
+            throw new RestApiException(ExamErrorStatus.NO_ACTIVE_SESSION);
+        }
+
+        return ActiveSessionResponse.from(exam, participant);
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/exam/ui/ExamController.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/ui/ExamController.java
@@ -5,8 +5,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.yd.vibecode.domain.exam.application.dto.response.ActiveSessionResponse;
 import com.yd.vibecode.domain.exam.application.dto.response.ExamStateResponse;
 import com.yd.vibecode.domain.exam.application.dto.response.ParticipantSessionResponse;
+import com.yd.vibecode.domain.exam.application.usecase.GetActiveSessionUseCase;
 import com.yd.vibecode.domain.exam.application.usecase.GetExamStateUseCase;
 import com.yd.vibecode.domain.exam.application.usecase.GetParticipantSessionUseCase;
 import com.yd.vibecode.global.annotation.CurrentUser;
@@ -27,6 +29,7 @@ public class ExamController implements ExamApi {
 
     private final GetExamStateUseCase getExamStateUseCase;
     private final GetParticipantSessionUseCase getParticipantSessionUseCase;
+    private final GetActiveSessionUseCase getActiveSessionUseCase;
 
     @GetMapping("/{examId}/state")
     @Override
@@ -40,6 +43,12 @@ public class ExamController implements ExamApi {
             @PathVariable Long examId,
             @CurrentUser String userId) {
         ParticipantSessionResponse response = getParticipantSessionUseCase.execute(examId, Long.parseLong(userId));
+        return BaseResponse.onSuccess(response);
+    }
+
+    @GetMapping("/active-session")
+    public BaseResponse<ActiveSessionResponse> getActiveSession(@CurrentUser String userId) {
+        ActiveSessionResponse response = getActiveSessionUseCase.execute(Long.parseLong(userId));
         return BaseResponse.onSuccess(response);
     }
 

--- a/src/main/java/com/yd/vibecode/domain/exam/ui/ExamController.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/ui/ExamController.java
@@ -13,6 +13,8 @@ import com.yd.vibecode.domain.exam.application.usecase.GetExamStateUseCase;
 import com.yd.vibecode.domain.exam.application.usecase.GetParticipantSessionUseCase;
 import com.yd.vibecode.global.annotation.CurrentUser;
 import com.yd.vibecode.global.common.BaseResponse;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
 import com.yd.vibecode.global.swagger.ExamApi;
 
 import lombok.RequiredArgsConstructor;
@@ -42,14 +44,22 @@ public class ExamController implements ExamApi {
     public BaseResponse<ParticipantSessionResponse> getMySession(
             @PathVariable Long examId,
             @CurrentUser String userId) {
-        ParticipantSessionResponse response = getParticipantSessionUseCase.execute(examId, Long.parseLong(userId));
+        ParticipantSessionResponse response = getParticipantSessionUseCase.execute(examId, parseUserId(userId));
         return BaseResponse.onSuccess(response);
     }
 
     @GetMapping("/active-session")
     public BaseResponse<ActiveSessionResponse> getActiveSession(@CurrentUser String userId) {
-        ActiveSessionResponse response = getActiveSessionUseCase.execute(Long.parseLong(userId));
+        ActiveSessionResponse response = getActiveSessionUseCase.execute(parseUserId(userId));
         return BaseResponse.onSuccess(response);
+    }
+
+    private Long parseUserId(String userId) {
+        try {
+            return Long.parseLong(userId);
+        } catch (NumberFormatException e) {
+            throw new RestApiException(AuthErrorStatus.INVALID_ACCESS_TOKEN);
+        }
     }
 
 }

--- a/src/main/java/com/yd/vibecode/global/config/WebSocketConfig.java
+++ b/src/main/java/com/yd/vibecode/global/config/WebSocketConfig.java
@@ -8,6 +8,7 @@ import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 import com.yd.vibecode.global.config.properties.CorsProperties;
+import com.yd.vibecode.global.interceptor.CookieHandshakeInterceptor;
 import com.yd.vibecode.global.security.StompPrincipalInterceptor;
 
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final CorsProperties corsProperties;
     private final StompPrincipalInterceptor stompPrincipalInterceptor;
+    private final CookieHandshakeInterceptor cookieHandshakeInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -45,6 +47,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         String[] allowedOrigins = corsProperties.getAllowedOrigins().split(",");
         registry.addEndpoint("/ws")
+                .addInterceptors(cookieHandshakeInterceptor)
                 .setAllowedOriginPatterns(allowedOrigins)
                 .withSockJS();
     }

--- a/src/main/java/com/yd/vibecode/global/exception/code/status/ExamErrorStatus.java
+++ b/src/main/java/com/yd/vibecode/global/exception/code/status/ExamErrorStatus.java
@@ -18,7 +18,8 @@ public enum ExamErrorStatus implements BaseCodeInterface {
     EXAM_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "EXAM004", "이미 시작된 시험입니다."),
     EXAM_ALREADY_ENDED(HttpStatus.BAD_REQUEST, "EXAM005", "이미 종료된 시험입니다."),
     EXAM_NOT_STARTED(HttpStatus.BAD_REQUEST, "EXAM006", "시험이 아직 시작되지 않았습니다."),
-    PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM007", "시험 참가자를 찾을 수 없습니다.")
+    PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM007", "시험 참가자를 찾을 수 없습니다."),
+    NO_ACTIVE_SESSION(HttpStatus.NOT_FOUND, "EXAM008", "현재 활성화된 시험 세션이 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/yd/vibecode/global/interceptor/CookieHandshakeInterceptor.java
+++ b/src/main/java/com/yd/vibecode/global/interceptor/CookieHandshakeInterceptor.java
@@ -1,0 +1,38 @@
+package com.yd.vibecode.global.interceptor;
+
+import java.util.Map;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import com.yd.vibecode.global.util.CookieUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CookieHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final CookieUtils cookieUtils;
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        if (request instanceof ServletServerHttpRequest servletRequest) {
+            String token = cookieUtils.getAccessTokenFromRequest(servletRequest.getServletRequest());
+            if (token != null) {
+                attributes.put(CookieUtils.ACCESS_TOKEN_COOKIE_NAME, token);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                WebSocketHandler wsHandler, Exception exception) {
+    }
+}

--- a/src/main/java/com/yd/vibecode/global/security/StompPrincipalInterceptor.java
+++ b/src/main/java/com/yd/vibecode/global/security/StompPrincipalInterceptor.java
@@ -1,6 +1,7 @@
 package com.yd.vibecode.global.security;
 
 import java.security.Principal;
+import java.util.Map;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -9,6 +10,8 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
+
+import com.yd.vibecode.global.util.CookieUtils;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,9 +39,8 @@ public class StompPrincipalInterceptor implements ChannelInterceptor {
                 MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
         if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
-            String authHeader = accessor.getFirstNativeHeader("Authorization");
-            if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                String token = authHeader.substring(7);
+            String token = extractToken(accessor);
+            if (token != null) {
                 if (tokenProvider.validateToken(token)) {
                     tokenProvider.getId(token).ifPresent(userId -> {
                         Principal principal = () -> userId;
@@ -47,7 +49,6 @@ public class StompPrincipalInterceptor implements ChannelInterceptor {
                     });
                 } else {
                     log.warn("[STOMP] 유효하지 않은 JWT 토큰으로 CONNECT 시도 - 연결 거부");
-                    // Principal 미설정 시 convertAndSendToUser가 무음 실패하므로 명시적 거부
                     throw new org.springframework.messaging.MessageDeliveryException(
                             message, "Invalid or expired JWT token");
                 }
@@ -55,5 +56,22 @@ public class StompPrincipalInterceptor implements ChannelInterceptor {
         }
 
         return message;
+    }
+
+    private String extractToken(StompHeaderAccessor accessor) {
+        // 1) 쿠키 기반 (CookieHandshakeInterceptor가 핸드셰이크 시 세션 attribute에 저장)
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes != null) {
+            Object tokenObj = sessionAttributes.get(CookieUtils.ACCESS_TOKEN_COOKIE_NAME);
+            if (tokenObj instanceof String token && !token.isBlank()) {
+                return token;
+            }
+        }
+        // 2) Authorization: Bearer 헤더 폴백
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/yd/vibecode/global/util/CookieUtils.java
+++ b/src/main/java/com/yd/vibecode/global/util/CookieUtils.java
@@ -31,6 +31,21 @@ public class CookieUtils {
         response.addHeader("Set-Cookie", buildSetCookieHeader(REFRESH_TOKEN_COOKIE_NAME, "", 0));
     }
 
+    public String getAccessTokenFromRequest(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                    String value = cookie.getValue();
+                    if (value != null && !value.isBlank()) {
+                        return value;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     public String getRefreshTokenFromRequest(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {

--- a/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCaseTest.java
@@ -1,0 +1,213 @@
+package com.yd.vibecode.domain.exam.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+
+import com.yd.vibecode.domain.exam.application.dto.response.ActiveSessionResponse;
+import com.yd.vibecode.domain.exam.domain.entity.Exam;
+import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
+import com.yd.vibecode.domain.exam.domain.entity.ExamState;
+import com.yd.vibecode.domain.exam.domain.service.ExamParticipantService;
+import com.yd.vibecode.domain.exam.domain.service.ExamService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.ExamErrorStatus;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class GetActiveSessionUseCaseTest {
+
+    @InjectMocks
+    private GetActiveSessionUseCase getActiveSessionUseCase;
+
+    @Mock
+    private ExamParticipantService examParticipantService;
+
+    @Mock
+    private ExamService examService;
+
+    @Test
+    @DisplayName("활성 세션 조회 성공 — RUNNING 시험의 모든 필드가 올바르게 반환된다")
+    void execute_returns_active_session_when_exam_is_running() {
+        // given
+        Long participantId = 100L;
+        Long examId = 1L;
+        LocalDateTime startsAt = LocalDateTime.of(2026, 5, 6, 9, 0);
+        LocalDateTime endsAt = LocalDateTime.of(2026, 5, 6, 11, 0);
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(participantId)
+                .specId(200L)
+                .assignedProblemId(300L)
+                .tokenLimit(50000)
+                .tokenUsed(1000)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 999L);
+
+        Exam exam = Exam.builder()
+                .title("테스트 시험")
+                .state(ExamState.RUNNING)
+                .startsAt(startsAt)
+                .endsAt(endsAt)
+                .createdBy(1L)
+                .build();
+        ReflectionTestUtils.setField(exam, "id", examId);
+
+        given(examParticipantService.findLatestByParticipantId(participantId)).willReturn(participant);
+        given(examService.findById(examId)).willReturn(exam);
+
+        // when
+        ActiveSessionResponse response = getActiveSessionUseCase.execute(participantId);
+
+        // then
+        assertThat(response.examId()).isEqualTo(examId);
+        assertThat(response.examParticipantId()).isEqualTo(999L);
+        assertThat(response.assignedProblemId()).isEqualTo(300L);
+        assertThat(response.specId()).isEqualTo(200L);
+        assertThat(response.examState()).isEqualTo(ExamState.RUNNING);
+        assertThat(response.startsAt()).isEqualTo(startsAt);
+        assertThat(response.endsAt()).isEqualTo(endsAt);
+        assertThat(response.serverTime()).isNotNull();
+        assertThat(response.tokenLimit()).isEqualTo(50000);
+        assertThat(response.tokenUsed()).isEqualTo(1000);
+    }
+
+    @Test
+    @DisplayName("활성 세션 조회 실패 — 참가 이력 없으면 NO_ACTIVE_SESSION 예외")
+    void execute_throws_when_no_participant_record() {
+        // given
+        given(examParticipantService.findLatestByParticipantId(999L)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> getActiveSessionUseCase.execute(999L))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> {
+                    RestApiException restEx = (RestApiException) ex;
+                    assertThat(restEx.getErrorCode().getCode())
+                            .isEqualTo(ExamErrorStatus.NO_ACTIVE_SESSION.getCode().getCode());
+                });
+    }
+
+    @Test
+    @DisplayName("활성 세션 조회 실패 — 최근 시험이 ENDED 상태면 NO_ACTIVE_SESSION 예외")
+    void execute_throws_when_latest_exam_is_ended() {
+        // given
+        Long participantId = 101L;
+        Long examId = 2L;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(participantId)
+                .tokenLimit(20000)
+                .tokenUsed(0)
+                .build();
+
+        Exam endedExam = Exam.builder()
+                .title("종료된 시험")
+                .state(ExamState.ENDED)
+                .startsAt(LocalDateTime.now().minusHours(3))
+                .endsAt(LocalDateTime.now().minusHours(1))
+                .createdBy(1L)
+                .build();
+        ReflectionTestUtils.setField(endedExam, "id", examId);
+
+        given(examParticipantService.findLatestByParticipantId(participantId)).willReturn(participant);
+        given(examService.findById(examId)).willReturn(endedExam);
+
+        // when & then
+        assertThatThrownBy(() -> getActiveSessionUseCase.execute(participantId))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> {
+                    RestApiException restEx = (RestApiException) ex;
+                    assertThat(restEx.getErrorCode().getCode())
+                            .isEqualTo(ExamErrorStatus.NO_ACTIVE_SESSION.getCode().getCode());
+                });
+    }
+
+    @Test
+    @DisplayName("활성 세션 조회 실패 — 최근 시험이 WAITING 상태면 NO_ACTIVE_SESSION 예외")
+    void execute_throws_when_latest_exam_is_waiting() {
+        // given
+        Long participantId = 102L;
+        Long examId = 3L;
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(participantId)
+                .tokenLimit(20000)
+                .tokenUsed(0)
+                .build();
+
+        Exam waitingExam = Exam.builder()
+                .title("대기 중 시험")
+                .state(ExamState.WAITING)
+                .startsAt(LocalDateTime.now().plusHours(1))
+                .endsAt(LocalDateTime.now().plusHours(3))
+                .createdBy(1L)
+                .build();
+        ReflectionTestUtils.setField(waitingExam, "id", examId);
+
+        given(examParticipantService.findLatestByParticipantId(participantId)).willReturn(participant);
+        given(examService.findById(examId)).willReturn(waitingExam);
+
+        // when & then
+        assertThatThrownBy(() -> getActiveSessionUseCase.execute(participantId))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> {
+                    RestApiException restEx = (RestApiException) ex;
+                    assertThat(restEx.getErrorCode().getCode())
+                            .isEqualTo(ExamErrorStatus.NO_ACTIVE_SESSION.getCode().getCode());
+                });
+    }
+
+    @Test
+    @DisplayName("ActiveSessionResponse.from() — Exam + ExamParticipant 의 모든 필드가 정확히 매핑된다")
+    void activeSessionResponse_from_maps_all_fields() {
+        // given
+        LocalDateTime startsAt = LocalDateTime.of(2026, 5, 6, 9, 0);
+        LocalDateTime endsAt = LocalDateTime.of(2026, 5, 6, 11, 0);
+
+        Exam exam = Exam.builder()
+                .title("시험")
+                .state(ExamState.RUNNING)
+                .startsAt(startsAt)
+                .endsAt(endsAt)
+                .createdBy(1L)
+                .build();
+        ReflectionTestUtils.setField(exam, "id", 10L);
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(10L)
+                .participantId(20L)
+                .specId(30L)
+                .assignedProblemId(40L)
+                .tokenLimit(55000)
+                .tokenUsed(5000)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 50L);
+
+        // when
+        ActiveSessionResponse response = ActiveSessionResponse.from(exam, participant);
+
+        // then
+        assertThat(response.examId()).isEqualTo(10L);
+        assertThat(response.examParticipantId()).isEqualTo(50L);
+        assertThat(response.specId()).isEqualTo(30L);
+        assertThat(response.assignedProblemId()).isEqualTo(40L);
+        assertThat(response.examState()).isEqualTo(ExamState.RUNNING);
+        assertThat(response.startsAt()).isEqualTo(startsAt);
+        assertThat(response.endsAt()).isEqualTo(endsAt);
+        assertThat(response.tokenLimit()).isEqualTo(55000);
+        assertThat(response.tokenUsed()).isEqualTo(5000);
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
@@ -2,7 +2,6 @@ package com.yd.vibecode.domain.exam.ui;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willReturn;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -22,8 +21,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.yd.vibecode.domain.exam.application.dto.response.ActiveSessionResponse;
-import com.yd.vibecode.domain.exam.application.dto.response.ExamStateResponse;
-import com.yd.vibecode.domain.exam.application.dto.response.ParticipantSessionResponse;
 import com.yd.vibecode.domain.exam.application.usecase.GetActiveSessionUseCase;
 import com.yd.vibecode.domain.exam.application.usecase.GetExamStateUseCase;
 import com.yd.vibecode.domain.exam.application.usecase.GetParticipantSessionUseCase;

--- a/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
@@ -1,0 +1,116 @@
+package com.yd.vibecode.domain.exam.ui;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willReturn;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.yd.vibecode.domain.exam.application.dto.response.ActiveSessionResponse;
+import com.yd.vibecode.domain.exam.application.dto.response.ExamStateResponse;
+import com.yd.vibecode.domain.exam.application.dto.response.ParticipantSessionResponse;
+import com.yd.vibecode.domain.exam.application.usecase.GetActiveSessionUseCase;
+import com.yd.vibecode.domain.exam.application.usecase.GetExamStateUseCase;
+import com.yd.vibecode.domain.exam.application.usecase.GetParticipantSessionUseCase;
+import com.yd.vibecode.domain.exam.domain.entity.ExamState;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.ExamErrorStatus;
+import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
+import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
+import com.yd.vibecode.global.security.SecurityConfig;
+import com.yd.vibecode.global.security.TokenProvider;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebMvcTest(
+    controllers = ExamController.class,
+    excludeAutoConfiguration = SecurityAutoConfiguration.class,
+    excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+)
+class ExamControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GetExamStateUseCase getExamStateUseCase;
+
+    @MockBean
+    private GetParticipantSessionUseCase getParticipantSessionUseCase;
+
+    @MockBean
+    private GetActiveSessionUseCase getActiveSessionUseCase;
+
+    @MockBean
+    private JwtBlacklistInterceptor jwtBlacklistInterceptor;
+
+    @MockBean
+    private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @Test
+    @DisplayName("활성 세션 조회 성공 — 200 OK와 세션 정보 반환")
+    void getActiveSession_success() throws Exception {
+        // given — JwtBlacklistInterceptor 통과, TokenProvider 모킹
+        given(jwtBlacklistInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any()))
+                .willReturn(true);
+        given(tokenProvider.getToken(any(HttpServletRequest.class)))
+                .willReturn(Optional.of("mock-token"));
+        given(tokenProvider.getId("mock-token"))
+                .willReturn(Optional.of("100"));
+
+        ActiveSessionResponse response = new ActiveSessionResponse(
+            1L, 999L, 300L, 200L,
+            ExamState.RUNNING,
+            LocalDateTime.of(2026, 5, 6, 9, 0),
+            LocalDateTime.of(2026, 5, 6, 11, 0),
+            LocalDateTime.now(),
+            50000, 1000
+        );
+        given(getActiveSessionUseCase.execute(100L)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/exams/active-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.examId").value(1))
+                .andExpect(jsonPath("$.result.examParticipantId").value(999))
+                .andExpect(jsonPath("$.result.examState").value("RUNNING"));
+    }
+
+    @Test
+    @DisplayName("활성 세션 조회 실패 — 활성 세션 없으면 404 반환")
+    void getActiveSession_not_found() throws Exception {
+        // given
+        given(jwtBlacklistInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any()))
+                .willReturn(true);
+        given(tokenProvider.getToken(any(HttpServletRequest.class)))
+                .willReturn(Optional.of("mock-token"));
+        given(tokenProvider.getId("mock-token"))
+                .willReturn(Optional.of("200"));
+
+        given(getActiveSessionUseCase.execute(200L))
+                .willThrow(new RestApiException(ExamErrorStatus.NO_ACTIVE_SESSION));
+
+        // when & then
+        mockMvc.perform(get("/api/exams/active-session"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/yd/vibecode/global/interceptor/CookieHandshakeInterceptorTest.java
+++ b/src/test/java/com/yd/vibecode/global/interceptor/CookieHandshakeInterceptorTest.java
@@ -1,0 +1,95 @@
+package com.yd.vibecode.global.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.socket.WebSocketHandler;
+
+import com.yd.vibecode.global.util.CookieUtils;
+
+import jakarta.servlet.http.Cookie;
+
+@ExtendWith(MockitoExtension.class)
+class CookieHandshakeInterceptorTest {
+
+    @InjectMocks
+    private CookieHandshakeInterceptor cookieHandshakeInterceptor;
+
+    @Mock
+    private CookieUtils cookieUtils;
+
+    @Mock
+    private WebSocketHandler wsHandler;
+
+    private MockHttpServletRequest mockRequest;
+    private MockHttpServletResponse mockResponse;
+    private Map<String, Object> attributes;
+
+    @BeforeEach
+    void setUp() {
+        mockRequest = new MockHttpServletRequest();
+        mockResponse = new MockHttpServletResponse();
+        attributes = new HashMap<>();
+    }
+
+    @Test
+    @DisplayName("access_token 쿠키 있으면 세션 attributes에 저장 후 true 반환")
+    void beforeHandshake_stores_token_when_cookie_present() throws Exception {
+        // given
+        String token = "valid-jwt-token";
+        mockRequest.setCookies(new Cookie(CookieUtils.ACCESS_TOKEN_COOKIE_NAME, token));
+        given(cookieUtils.getAccessTokenFromRequest(mockRequest)).willReturn(token);
+
+        ServletServerHttpRequest request = new ServletServerHttpRequest(mockRequest);
+        ServletServerHttpResponse response = new ServletServerHttpResponse(mockResponse);
+
+        // when
+        boolean result = cookieHandshakeInterceptor.beforeHandshake(request, response, wsHandler, attributes);
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(attributes.get(CookieUtils.ACCESS_TOKEN_COOKIE_NAME)).isEqualTo(token);
+    }
+
+    @Test
+    @DisplayName("access_token 쿠키 없으면 attributes 변경 없이 true 반환")
+    void beforeHandshake_returns_true_without_modifying_attributes_when_no_cookie() throws Exception {
+        // given
+        given(cookieUtils.getAccessTokenFromRequest(mockRequest)).willReturn(null);
+
+        ServletServerHttpRequest request = new ServletServerHttpRequest(mockRequest);
+        ServletServerHttpResponse response = new ServletServerHttpResponse(mockResponse);
+
+        // when
+        boolean result = cookieHandshakeInterceptor.beforeHandshake(request, response, wsHandler, attributes);
+
+        // then
+        assertThat(result).isTrue();
+        assertThat(attributes).doesNotContainKey(CookieUtils.ACCESS_TOKEN_COOKIE_NAME);
+    }
+
+    @Test
+    @DisplayName("afterHandshake — 예외 없이 완료된다")
+    void afterHandshake_completes_without_exception() {
+        // given
+        ServletServerHttpRequest request = new ServletServerHttpRequest(mockRequest);
+        ServletServerHttpResponse response = new ServletServerHttpResponse(mockResponse);
+
+        // when & then (예외 없이 완료되어야 함)
+        cookieHandshakeInterceptor.afterHandshake(request, response, wsHandler, null);
+    }
+}

--- a/src/test/java/com/yd/vibecode/global/security/StompPrincipalInterceptorTest.java
+++ b/src/test/java/com/yd/vibecode/global/security/StompPrincipalInterceptorTest.java
@@ -1,0 +1,176 @@
+package com.yd.vibecode.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import com.yd.vibecode.global.util.CookieUtils;
+
+@ExtendWith(MockitoExtension.class)
+class StompPrincipalInterceptorTest {
+
+    @InjectMocks
+    private StompPrincipalInterceptor interceptor;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    private Message<?> buildConnectMessage(String authHeader, Map<String, Object> sessionAttributes) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+        if (authHeader != null) {
+            accessor.addNativeHeader("Authorization", authHeader);
+        }
+        if (sessionAttributes != null) {
+            accessor.setSessionAttributes(sessionAttributes);
+        }
+        accessor.setLeaveMutable(true);
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    // -------------------------------------------------------------------------
+    // 1. 쿠키 기반 인증 (세션 attribute)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("세션 attribute의 쿠키 토큰으로 Principal 설정 성공")
+    void preSend_sets_principal_from_cookie_session_attribute() {
+        // given
+        String token = "valid-cookie-token";
+        Map<String, Object> sessionAttrs = new HashMap<>();
+        sessionAttrs.put(CookieUtils.ACCESS_TOKEN_COOKIE_NAME, token);
+
+        Message<?> message = buildConnectMessage(null, sessionAttrs);
+
+        given(tokenProvider.validateToken(token)).willReturn(true);
+        given(tokenProvider.getId(token)).willReturn(Optional.of("100"));
+
+        // when
+        Message<?> result = interceptor.preSend(message, null);
+
+        // then
+        StompHeaderAccessor resultAccessor = StompHeaderAccessor.wrap(result);
+        assertThat(resultAccessor.getUser()).isNotNull();
+        assertThat(resultAccessor.getUser().getName()).isEqualTo("100");
+    }
+
+    // -------------------------------------------------------------------------
+    // 2. Authorization 헤더 기반 인증 (폴백)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Authorization Bearer 헤더로 Principal 설정 성공 (쿠키 없는 경우)")
+    void preSend_sets_principal_from_bearer_header_when_no_cookie() {
+        // given
+        String token = "valid-header-token";
+        Message<?> message = buildConnectMessage("Bearer " + token, new HashMap<>());
+
+        given(tokenProvider.validateToken(token)).willReturn(true);
+        given(tokenProvider.getId(token)).willReturn(Optional.of("200"));
+
+        // when
+        Message<?> result = interceptor.preSend(message, null);
+
+        // then
+        StompHeaderAccessor resultAccessor = StompHeaderAccessor.wrap(result);
+        assertThat(resultAccessor.getUser()).isNotNull();
+        assertThat(resultAccessor.getUser().getName()).isEqualTo("200");
+    }
+
+    // -------------------------------------------------------------------------
+    // 3. 쿠키 우선 순위
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("쿠키와 헤더 둘 다 있으면 쿠키 토큰 우선 사용")
+    void preSend_prefers_cookie_over_bearer_header() {
+        // given
+        String cookieToken = "cookie-token";
+        String headerToken = "header-token";
+
+        Map<String, Object> sessionAttrs = new HashMap<>();
+        sessionAttrs.put(CookieUtils.ACCESS_TOKEN_COOKIE_NAME, cookieToken);
+
+        Message<?> message = buildConnectMessage("Bearer " + headerToken, sessionAttrs);
+
+        given(tokenProvider.validateToken(cookieToken)).willReturn(true);
+        given(tokenProvider.getId(cookieToken)).willReturn(Optional.of("300"));
+
+        // when
+        Message<?> result = interceptor.preSend(message, null);
+
+        // then — headerToken은 검증되지 않아야 함, cookieToken으로 설정
+        StompHeaderAccessor resultAccessor = StompHeaderAccessor.wrap(result);
+        assertThat(resultAccessor.getUser().getName()).isEqualTo("300");
+    }
+
+    // -------------------------------------------------------------------------
+    // 4. 유효하지 않은 토큰 — 연결 거부
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("유효하지 않은 토큰이면 MessageDeliveryException 발생")
+    void preSend_throws_when_token_is_invalid() {
+        // given
+        String invalidToken = "invalid-token";
+        Message<?> message = buildConnectMessage("Bearer " + invalidToken, new HashMap<>());
+
+        given(tokenProvider.validateToken(invalidToken)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> interceptor.preSend(message, null))
+                .isInstanceOf(MessageDeliveryException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // 5. 토큰 없는 경우 — 통과 (Principal 미설정)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("토큰이 전혀 없으면 Principal 미설정 상태로 통과")
+    void preSend_passes_through_when_no_token() {
+        // given — sessionAttributes 없음, Authorization 헤더 없음
+        Message<?> message = buildConnectMessage(null, new HashMap<>());
+
+        // when
+        Message<?> result = interceptor.preSend(message, null);
+
+        // then — 예외 없이 반환, Principal null
+        StompHeaderAccessor resultAccessor = StompHeaderAccessor.wrap(result);
+        assertThat(resultAccessor.getUser()).isNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // 6. CONNECT 아닌 프레임은 그대로 통과
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("SUBSCRIBE 프레임은 토큰 검사 없이 그대로 통과")
+    void preSend_passes_non_connect_frames_without_processing() {
+        // given
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setLeaveMutable(true);
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        // when — tokenProvider 호출 없이 통과되어야 함
+        Message<?> result = interceptor.preSend(message, null);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary

- `GET /api/exams/active-session` 엔드포인트 추가 — examId 없이 현재 참가자의 활성 시험 세션 정보 조회 (FE 세션 복구 지원)
- WebSocket STOMP 핸드셰이크 시 HttpOnly 쿠키에서 JWT를 추출하는 `CookieHandshakeInterceptor` 추가
- `StompPrincipalInterceptor`에 쿠키 기반 인증 처리 추가 (Authorization Bearer 헤더 폴백 유지)

## Changes

### 활성 시험 세션 조회 API (`GET /api/exams/active-session`)
- `ActiveSessionResponse` DTO — examId, examParticipantId, assignedProblemId, specId, examState, startsAt, endsAt, serverTime, tokenLimit, tokenUsed
- `GetActiveSessionUseCase` — `findLatestByParticipantId()` + `isRunning()` 체크로 활성 세션 반환
- `ExamErrorStatus.NO_ACTIVE_SESSION` (EXAM008, 404) 추가
- `ExamController`에 `@GetMapping("/active-session")` 등록

### WebSocket 쿠키 기반 인증
- `CookieHandshakeInterceptor` — HTTP 업그레이드 핸드셰이크 시 `access_token` 쿠키를 WebSocket 세션 attribute에 저장
- `StompPrincipalInterceptor` — STOMP CONNECT 시 세션 attribute(쿠키) 우선 조회, 없으면 Authorization 헤더 폴백
- `CookieUtils.getAccessTokenFromRequest()` 메서드 추가
- `WebSocketConfig`에 `CookieHandshakeInterceptor` 인터셉터 등록

## Tests

| 테스트 클래스 | 케이스 수 |
|---|---|
| `GetActiveSessionUseCaseTest` | 5 (성공·활성 세션 없음·종료된 시험·대기 중 시험·DTO 매핑) |
| `ExamControllerTest` | 2 (200 성공·404 세션 없음) |
| `CookieHandshakeInterceptorTest` | 3 (쿠키 있음·쿠키 없음·afterHandshake) |
| `StompPrincipalInterceptorTest` | 6 (쿠키 인증·헤더 인증·쿠키 우선순위·유효하지 않은 토큰·토큰 없음·CONNECT 외 프레임) |

## Test plan

- [x] `./gradlew test` 전체 통과 확인
- [x] `GET /api/exams/active-session` — 활성 세션 있을 때 200 + 세션 정보 반환
- [x] `GET /api/exams/active-session` — 활성 세션 없을 때 404 (EXAM008) 반환
- [x] WebSocket STOMP 연결 — access_token 쿠키만으로 CONNECT → `user-name` Principal 설정 확인
- [x] WebSocket STOMP 연결 — Authorization Bearer 헤더로도 CONNECT 가능 확인