### PR TITLE
fix: support Long type in CurrentUser resolver

### DIFF
--- a/src/main/java/com/yd/vibecode/global/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/yd/vibecode/global/resolver/CurrentUserArgumentResolver.java
@@ -1,5 +1,6 @@
 package com.yd.vibecode.global.resolver;
 
+import static com.yd.vibecode.global.exception.code.status.AuthErrorStatus.INVALID_ACCESS_TOKEN;
 import static com.yd.vibecode.global.exception.code.status.GlobalErrorStatus._UNAUTHORIZED;
 
 import com.yd.vibecode.global.annotation.CurrentUser;
@@ -20,13 +21,17 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        boolean supported = parameter.getParameterAnnotation(CurrentUser.class) != null
-                && String.class.isAssignableFrom(parameter.getParameterType());
-        return supported;
+        if (parameter.getParameterAnnotation(CurrentUser.class) == null) {
+            return false;
+        }
+        Class<?> type = parameter.getParameterType();
+        return String.class.isAssignableFrom(type)
+                || Long.class.equals(type)
+                || long.class.equals(type);
     }
 
     @Override
-    public String resolveArgument(MethodParameter parameter,
+    public Object resolveArgument(MethodParameter parameter,
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) throws Exception {
@@ -46,6 +51,15 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
                 .orElseThrow(() -> {
                     return new RestApiException(_UNAUTHORIZED);
                 });
+
+        Class<?> paramType = parameter.getParameterType();
+        if (Long.class.equals(paramType) || long.class.equals(paramType)) {
+            try {
+                return Long.parseLong(userId);
+            } catch (NumberFormatException e) {
+                throw new RestApiException(INVALID_ACCESS_TOKEN);
+            }
+        }
 
         return userId;
     }

--- a/src/main/java/com/yd/vibecode/global/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/yd/vibecode/global/resolver/CurrentUserArgumentResolver.java
@@ -47,9 +47,17 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
                     return new RestApiException(_UNAUTHORIZED);
                 });
 
+        // refresh token이 access token cookie/header를 통해 전달되어
+        // 인증된 호출처럼 사용되는 것을 방지한다. (RefreshTokenArgumentResolver와 대칭)
+        if (!tokenProvider.isAccessToken(token)) {
+            throw new RestApiException(INVALID_ACCESS_TOKEN);
+        }
+
+        // token은 존재하지만 id 클레임을 추출할 수 없다면 토큰 자체의 문제이므로
+        // MeUseCase와 동일하게 INVALID_ACCESS_TOKEN으로 통일한다.
         String userId = tokenProvider.getId(token)
                 .orElseThrow(() -> {
-                    return new RestApiException(_UNAUTHORIZED);
+                    return new RestApiException(INVALID_ACCESS_TOKEN);
                 });
 
         Class<?> paramType = parameter.getParameterType();

--- a/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
@@ -71,6 +71,7 @@ class ExamControllerTest {
                 .willReturn(true);
         given(tokenProvider.getToken(any(HttpServletRequest.class)))
                 .willReturn(Optional.of("mock-token"));
+        given(tokenProvider.isAccessToken("mock-token")).willReturn(true);
         given(tokenProvider.getId("mock-token"))
                 .willReturn(Optional.of("100"));
 
@@ -100,6 +101,7 @@ class ExamControllerTest {
                 .willReturn(true);
         given(tokenProvider.getToken(any(HttpServletRequest.class)))
                 .willReturn(Optional.of("mock-token"));
+        given(tokenProvider.isAccessToken("mock-token")).willReturn(true);
         given(tokenProvider.getId("mock-token"))
                 .willReturn(Optional.of("200"));
 

--- a/src/test/java/com/yd/vibecode/global/resolver/CurrentUserArgumentResolverTest.java
+++ b/src/test/java/com/yd/vibecode/global/resolver/CurrentUserArgumentResolverTest.java
@@ -1,0 +1,214 @@
+package com.yd.vibecode.global.resolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+
+import com.yd.vibecode.global.annotation.CurrentUser;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
+import com.yd.vibecode.global.security.TokenProvider;
+
+@ExtendWith(MockitoExtension.class)
+class CurrentUserArgumentResolverTest {
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    private CurrentUserArgumentResolver resolver;
+
+    private MockHttpServletRequest mockRequest;
+    private ServletWebRequest webRequest;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new CurrentUserArgumentResolver(tokenProvider);
+        mockRequest = new MockHttpServletRequest();
+        webRequest = new ServletWebRequest(mockRequest);
+    }
+
+    /**
+     * 테스트 전용 메서드 시그니처 모음. 리플렉션으로 MethodParameter를 만들어
+     * supportsParameter / resolveArgument 흐름을 검증한다.
+     */
+    @SuppressWarnings("unused")
+    static class SampleHandlers {
+        public void stringParam(@CurrentUser String userId) {}
+        public void longBoxedParam(@CurrentUser Long userId) {}
+        public void longPrimitiveParam(@CurrentUser long userId) {}
+        public void integerParam(@CurrentUser Integer userId) {}
+        public void noAnnotationStringParam(String userId) {}
+    }
+
+    private MethodParameter parameterOf(String methodName) throws NoSuchMethodException {
+        for (Method method : SampleHandlers.class.getDeclaredMethods()) {
+            if (method.getName().equals(methodName)) {
+                return new MethodParameter(method, 0);
+            }
+        }
+        throw new NoSuchMethodException(methodName);
+    }
+
+    @Nested
+    @DisplayName("supportsParameter")
+    class SupportsParameter {
+
+        @Test
+        @DisplayName("@CurrentUser String 파라미터는 지원한다")
+        void supports_string_parameter() throws Exception {
+            MethodParameter parameter = parameterOf("stringParam");
+
+            assertThat(resolver.supportsParameter(parameter)).isTrue();
+        }
+
+        @Test
+        @DisplayName("@CurrentUser Long 파라미터는 지원한다")
+        void supports_long_boxed_parameter() throws Exception {
+            MethodParameter parameter = parameterOf("longBoxedParam");
+
+            assertThat(resolver.supportsParameter(parameter)).isTrue();
+        }
+
+        @Test
+        @DisplayName("@CurrentUser long primitive 파라미터는 지원한다")
+        void supports_long_primitive_parameter() throws Exception {
+            MethodParameter parameter = parameterOf("longPrimitiveParam");
+
+            assertThat(resolver.supportsParameter(parameter)).isTrue();
+        }
+
+        @Test
+        @DisplayName("@CurrentUser가 붙은 지원하지 않는 타입(Integer)은 false를 반환한다")
+        void does_not_support_unsupported_type() throws Exception {
+            MethodParameter parameter = parameterOf("integerParam");
+
+            assertThat(resolver.supportsParameter(parameter)).isFalse();
+        }
+
+        @Test
+        @DisplayName("@CurrentUser 어노테이션이 없으면 false를 반환한다")
+        void does_not_support_when_annotation_missing() throws Exception {
+            MethodParameter parameter = parameterOf("noAnnotationStringParam");
+
+            assertThat(resolver.supportsParameter(parameter)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveArgument")
+    class ResolveArgument {
+
+        @Test
+        @DisplayName("String 파라미터는 토큰에서 추출한 userId 문자열을 그대로 반환한다")
+        void returns_string_user_id_for_string_parameter() throws Exception {
+            MethodParameter parameter = parameterOf("stringParam");
+            String token = "valid-access-token";
+            given(tokenProvider.getToken(mockRequest)).willReturn(Optional.of(token));
+            given(tokenProvider.isAccessToken(token)).willReturn(true);
+            given(tokenProvider.getId(token)).willReturn(Optional.of("42"));
+
+            Object result = resolver.resolveArgument(parameter, null, webRequest, null);
+
+            assertThat(result).isInstanceOf(String.class).isEqualTo("42");
+        }
+
+        @Test
+        @DisplayName("Long 파라미터는 userId를 Long으로 파싱해 반환한다")
+        void returns_long_for_long_boxed_parameter() throws Exception {
+            MethodParameter parameter = parameterOf("longBoxedParam");
+            String token = "valid-access-token";
+            given(tokenProvider.getToken(mockRequest)).willReturn(Optional.of(token));
+            given(tokenProvider.isAccessToken(token)).willReturn(true);
+            given(tokenProvider.getId(token)).willReturn(Optional.of("123"));
+
+            Object result = resolver.resolveArgument(parameter, null, webRequest, null);
+
+            assertThat(result).isInstanceOf(Long.class).isEqualTo(123L);
+        }
+
+        @Test
+        @DisplayName("long primitive 파라미터도 Long 값으로 반환한다 (오토박싱)")
+        void returns_long_for_long_primitive_parameter() throws Exception {
+            MethodParameter parameter = parameterOf("longPrimitiveParam");
+            String token = "valid-access-token";
+            given(tokenProvider.getToken(mockRequest)).willReturn(Optional.of(token));
+            given(tokenProvider.isAccessToken(token)).willReturn(true);
+            given(tokenProvider.getId(token)).willReturn(Optional.of("456"));
+
+            Object result = resolver.resolveArgument(parameter, null, webRequest, null);
+
+            assertThat(result).isInstanceOf(Long.class).isEqualTo(456L);
+        }
+
+        @Test
+        @DisplayName("Long 파라미터인데 userId가 숫자가 아니면 INVALID_ACCESS_TOKEN 예외를 던진다")
+        void throws_invalid_access_token_when_user_id_is_not_numeric() throws Exception {
+            MethodParameter parameter = parameterOf("longBoxedParam");
+            String token = "valid-access-token";
+            given(tokenProvider.getToken(mockRequest)).willReturn(Optional.of(token));
+            given(tokenProvider.isAccessToken(token)).willReturn(true);
+            given(tokenProvider.getId(token)).willReturn(Optional.of("not-a-number"));
+
+            assertThatThrownBy(() -> resolver.resolveArgument(parameter, null, webRequest, null))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(AuthErrorStatus.INVALID_ACCESS_TOKEN.getCode());
+        }
+
+        @Test
+        @DisplayName("요청에서 토큰을 찾지 못하면 _UNAUTHORIZED 예외를 던진다")
+        void throws_unauthorized_when_token_missing() throws Exception {
+            MethodParameter parameter = parameterOf("stringParam");
+            given(tokenProvider.getToken(mockRequest)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> resolver.resolveArgument(parameter, null, webRequest, null))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(GlobalErrorStatus._UNAUTHORIZED.getCode());
+        }
+
+        @Test
+        @DisplayName("토큰은 있으나 getId에서 userId를 추출하지 못하면 INVALID_ACCESS_TOKEN 예외를 던진다 (MeUseCase와 일관)")
+        void throws_invalid_access_token_when_get_id_returns_empty() throws Exception {
+            MethodParameter parameter = parameterOf("stringParam");
+            String token = "valid-access-token";
+            given(tokenProvider.getToken(mockRequest)).willReturn(Optional.of(token));
+            given(tokenProvider.isAccessToken(token)).willReturn(true);
+            given(tokenProvider.getId(token)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> resolver.resolveArgument(parameter, null, webRequest, null))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(AuthErrorStatus.INVALID_ACCESS_TOKEN.getCode());
+        }
+
+        @Test
+        @DisplayName("refresh token이 access token 자리로 전달되면 INVALID_ACCESS_TOKEN 예외를 던진다")
+        void throws_invalid_access_token_when_refresh_token_is_used() throws Exception {
+            MethodParameter parameter = parameterOf("longBoxedParam");
+            String refreshToken = "refresh-token-value";
+            given(tokenProvider.getToken(mockRequest)).willReturn(Optional.of(refreshToken));
+            given(tokenProvider.isAccessToken(refreshToken)).willReturn(false);
+
+            assertThatThrownBy(() -> resolver.resolveArgument(parameter, null, webRequest, null))
+                    .isInstanceOf(RestApiException.class)
+                    .extracting(e -> ((RestApiException) e).getErrorCode())
+                    .isEqualTo(AuthErrorStatus.INVALID_ACCESS_TOKEN.getCode());
+        }
+    }
+}


### PR DESCRIPTION
## 수정 내용

- `CurrentUserArgumentResolver`에서 `@CurrentUser Long` / `long` 타입 파라미터를 지원하도록 수정했습니다.
- 기존에는 `@CurrentUser String` 타입만 처리되어, `@CurrentUser Long userId`를 사용하는 API에서 사용자 ID가 정상 주입되지 않는 문제가 있었습니다.
- 토큰에서 추출한 사용자 ID 문자열을 `Long.parseLong()`으로 변환하도록 처리했습니다.
- 변환 실패 시 `INVALID_ACCESS_TOKEN` 예외가 발생하도록 했습니다.

## 확인 내용

- `compileJava` 성공 확인
- `/api/exams/{examId}/assignment` 호출 후 문제 데이터가 정상 조회되는 것 확인
- `/test` 화면에서 기존 “문제를 불러올 수 없습니다.” 대신 문제 제목/본문이 표시되는 것 확인