### PR TITLE
fix: add exam-scoped active session lookup

### DIFF
--- a/src/main/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCase.java
@@ -37,13 +37,13 @@ public class GetActiveSessionUseCase {
 
     @Transactional(readOnly = true)
     public ActiveSessionResponse execute(Long examId, Long participantId) {
-        ExamParticipant participant = examParticipantService.findByExamIdAndParticipantId(examId, participantId);
-        if (participant == null) {
+        Exam exam = examService.findById(examId);
+        if (!exam.isRunning()) {
             throw new RestApiException(ExamErrorStatus.NO_ACTIVE_SESSION);
         }
 
-        Exam exam = examService.findById(examId);
-        if (!exam.isRunning()) {
+        ExamParticipant participant = examParticipantService.findByExamIdAndParticipantId(examId, participantId);
+        if (participant == null) {
             throw new RestApiException(ExamErrorStatus.NO_ACTIVE_SESSION);
         }
 

--- a/src/main/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCase.java
@@ -34,4 +34,19 @@ public class GetActiveSessionUseCase {
 
         return ActiveSessionResponse.from(exam, participant);
     }
+
+    @Transactional(readOnly = true)
+    public ActiveSessionResponse execute(Long examId, Long participantId) {
+        ExamParticipant participant = examParticipantService.findByExamIdAndParticipantId(examId, participantId);
+        if (participant == null) {
+            throw new RestApiException(ExamErrorStatus.NO_ACTIVE_SESSION);
+        }
+
+        Exam exam = examService.findById(examId);
+        if (!exam.isRunning()) {
+            throw new RestApiException(ExamErrorStatus.NO_ACTIVE_SESSION);
+        }
+
+        return ActiveSessionResponse.from(exam, participant);
+    }
 }

--- a/src/main/java/com/yd/vibecode/domain/exam/ui/ExamController.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/ui/ExamController.java
@@ -54,6 +54,14 @@ public class ExamController implements ExamApi {
         return BaseResponse.onSuccess(response);
     }
 
+    @GetMapping("/{examId}/active-session")
+    public BaseResponse<ActiveSessionResponse> getActiveSessionByExam(
+            @PathVariable Long examId,
+            @CurrentUser String userId) {
+        ActiveSessionResponse response = getActiveSessionUseCase.execute(examId, parseUserId(userId));
+        return BaseResponse.onSuccess(response);
+    }
+
     private Long parseUserId(String userId) {
         try {
             return Long.parseLong(userId);

--- a/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCaseTest.java
@@ -83,6 +83,46 @@ class GetActiveSessionUseCaseTest {
     }
 
     @Test
+    @DisplayName("시험 ID 기준 활성 세션 조회 성공 — 지정 시험의 참가 기록과 RUNNING 상태를 확인한다")
+    void execute_by_exam_id_returns_session_for_requested_exam() {
+        // given
+        Long participantId = 100L;
+        Long examId = 1L;
+        LocalDateTime startsAt = LocalDateTime.of(2026, 5, 6, 9, 0);
+        LocalDateTime endsAt = LocalDateTime.of(2026, 5, 6, 11, 0);
+
+        ExamParticipant participant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(participantId)
+                .specId(200L)
+                .assignedProblemId(300L)
+                .tokenLimit(50000)
+                .tokenUsed(1000)
+                .build();
+        ReflectionTestUtils.setField(participant, "id", 999L);
+
+        Exam exam = Exam.builder()
+                .title("진행 중 시험")
+                .state(ExamState.RUNNING)
+                .startsAt(startsAt)
+                .endsAt(endsAt)
+                .createdBy(1L)
+                .build();
+        ReflectionTestUtils.setField(exam, "id", examId);
+
+        given(examParticipantService.findByExamIdAndParticipantId(examId, participantId)).willReturn(participant);
+        given(examService.findById(examId)).willReturn(exam);
+
+        // when
+        ActiveSessionResponse response = getActiveSessionUseCase.execute(examId, participantId);
+
+        // then
+        assertThat(response.examId()).isEqualTo(examId);
+        assertThat(response.examState()).isEqualTo(ExamState.RUNNING);
+        assertThat(response.examParticipantId()).isEqualTo(999L);
+    }
+
+    @Test
     @DisplayName("활성 세션 조회 실패 — 참가 이력 없으면 NO_ACTIVE_SESSION 예외")
     void execute_throws_when_no_participant_record() {
         // given
@@ -162,6 +202,24 @@ class GetActiveSessionUseCaseTest {
 
         // when & then
         assertThatThrownBy(() -> getActiveSessionUseCase.execute(participantId))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> {
+                    RestApiException restEx = (RestApiException) ex;
+                    assertThat(restEx.getErrorCode().getCode())
+                            .isEqualTo(ExamErrorStatus.NO_ACTIVE_SESSION.getCode().getCode());
+                });
+    }
+
+    @Test
+    @DisplayName("시험 ID 기준 활성 세션 조회 실패 — 지정 시험 참가 기록이 없으면 NO_ACTIVE_SESSION 예외")
+    void execute_by_exam_id_throws_when_participant_record_does_not_exist() {
+        // given
+        Long examId = 1L;
+        Long participantId = 999L;
+        given(examParticipantService.findByExamIdAndParticipantId(examId, participantId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> getActiveSessionUseCase.execute(examId, participantId))
                 .isInstanceOf(RestApiException.class)
                 .satisfies(ex -> {
                     RestApiException restEx = (RestApiException) ex;

--- a/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCaseTest.java
@@ -216,7 +216,46 @@ class GetActiveSessionUseCaseTest {
         // given
         Long examId = 1L;
         Long participantId = 999L;
+
+        Exam runningExam = Exam.builder()
+                .title("진행 중 시험")
+                .state(ExamState.RUNNING)
+                .startsAt(LocalDateTime.now().minusHours(1))
+                .endsAt(LocalDateTime.now().plusHours(1))
+                .createdBy(1L)
+                .build();
+        ReflectionTestUtils.setField(runningExam, "id", examId);
+
+        given(examService.findById(examId)).willReturn(runningExam);
         given(examParticipantService.findByExamIdAndParticipantId(examId, participantId)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> getActiveSessionUseCase.execute(examId, participantId))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> {
+                    RestApiException restEx = (RestApiException) ex;
+                    assertThat(restEx.getErrorCode().getCode())
+                            .isEqualTo(ExamErrorStatus.NO_ACTIVE_SESSION.getCode().getCode());
+                });
+    }
+
+    @Test
+    @DisplayName("시험 ID 기준 활성 세션 조회 실패 — 시험이 RUNNING 아니면 NO_ACTIVE_SESSION 예외")
+    void execute_by_exam_id_throws_when_exam_is_not_running() {
+        // given
+        Long examId = 1L;
+        Long participantId = 100L;
+
+        Exam waitingExam = Exam.builder()
+                .title("대기 중 시험")
+                .state(ExamState.WAITING)
+                .startsAt(LocalDateTime.now().plusHours(1))
+                .endsAt(LocalDateTime.now().plusHours(3))
+                .createdBy(1L)
+                .build();
+        ReflectionTestUtils.setField(waitingExam, "id", examId);
+
+        given(examService.findById(examId)).willReturn(waitingExam);
 
         // when & then
         assertThatThrownBy(() -> getActiveSessionUseCase.execute(examId, participantId))

--- a/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,17 +64,20 @@ class ExamControllerTest {
     @MockBean
     private TokenProvider tokenProvider;
 
-    @Test
-    @DisplayName("활성 세션 조회 성공 — 200 OK와 세션 정보 반환")
-    void getActiveSession_success() throws Exception {
-        // given — JwtBlacklistInterceptor 통과, TokenProvider 모킹
+    @BeforeEach
+    void setUpAuth() throws Exception {
         given(jwtBlacklistInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any()))
                 .willReturn(true);
         given(tokenProvider.getToken(any(HttpServletRequest.class)))
                 .willReturn(Optional.of("mock-token"));
         given(tokenProvider.getId("mock-token"))
                 .willReturn(Optional.of("100"));
+    }
 
+    @Test
+    @DisplayName("활성 세션 조회 성공 — 200 OK와 세션 정보 반환")
+    void getActiveSession_success() throws Exception {
+        // given
         ActiveSessionResponse response = new ActiveSessionResponse(
             1L, 999L, 300L, 200L,
             ExamState.RUNNING,
@@ -96,13 +100,6 @@ class ExamControllerTest {
     @DisplayName("시험 ID 기준 활성 세션 조회 성공 — 200 OK와 세션 정보 반환")
     void getActiveSessionByExam_success() throws Exception {
         // given
-        given(jwtBlacklistInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any()))
-                .willReturn(true);
-        given(tokenProvider.getToken(any(HttpServletRequest.class)))
-                .willReturn(Optional.of("mock-token"));
-        given(tokenProvider.getId("mock-token"))
-                .willReturn(Optional.of("100"));
-
         ActiveSessionResponse response = new ActiveSessionResponse(
             1L, 999L, 300L, 200L,
             ExamState.RUNNING,
@@ -124,19 +121,25 @@ class ExamControllerTest {
     @Test
     @DisplayName("활성 세션 조회 실패 — 활성 세션 없으면 404 반환")
     void getActiveSession_not_found() throws Exception {
-        // given
-        given(jwtBlacklistInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any()))
-                .willReturn(true);
-        given(tokenProvider.getToken(any(HttpServletRequest.class)))
-                .willReturn(Optional.of("mock-token"));
-        given(tokenProvider.getId("mock-token"))
-                .willReturn(Optional.of("200"));
-
+        // given — @BeforeEach가 세운 "100" 스터빙을 "200"으로 덮어씀
+        given(tokenProvider.getId("mock-token")).willReturn(Optional.of("200"));
         given(getActiveSessionUseCase.execute(200L))
                 .willThrow(new RestApiException(ExamErrorStatus.NO_ACTIVE_SESSION));
 
         // when & then
         mockMvc.perform(get("/api/exams/active-session"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("시험 ID 기준 활성 세션 조회 실패 — 활성 세션 없으면 404 반환")
+    void getActiveSessionByExam_not_found() throws Exception {
+        // given
+        given(getActiveSessionUseCase.execute(1L, 100L))
+                .willThrow(new RestApiException(ExamErrorStatus.NO_ACTIVE_SESSION));
+
+        // when & then
+        mockMvc.perform(get("/api/exams/1/active-session"))
                 .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
@@ -93,6 +93,35 @@ class ExamControllerTest {
     }
 
     @Test
+    @DisplayName("시험 ID 기준 활성 세션 조회 성공 — 200 OK와 세션 정보 반환")
+    void getActiveSessionByExam_success() throws Exception {
+        // given
+        given(jwtBlacklistInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any()))
+                .willReturn(true);
+        given(tokenProvider.getToken(any(HttpServletRequest.class)))
+                .willReturn(Optional.of("mock-token"));
+        given(tokenProvider.getId("mock-token"))
+                .willReturn(Optional.of("100"));
+
+        ActiveSessionResponse response = new ActiveSessionResponse(
+            1L, 999L, 300L, 200L,
+            ExamState.RUNNING,
+            LocalDateTime.of(2026, 5, 6, 9, 0),
+            LocalDateTime.of(2026, 5, 6, 11, 0),
+            LocalDateTime.now(),
+            50000, 1000
+        );
+        given(getActiveSessionUseCase.execute(1L, 100L)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/exams/1/active-session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.examId").value(1))
+                .andExpect(jsonPath("$.result.examParticipantId").value(999))
+                .andExpect(jsonPath("$.result.examState").value("RUNNING"));
+    }
+
+    @Test
     @DisplayName("활성 세션 조회 실패 — 활성 세션 없으면 404 반환")
     void getActiveSession_not_found() throws Exception {
         // given


### PR DESCRIPTION
## 수정 내용

  - 시험 ID 기준 active-session 조회 API를 추가했습니다.
    - `GET /api/exams/{examId}/active-session`
  - 기존 `GET /api/exams/active-session`은 유지했습니다.
  - 새 API는 `examId + 현재 사용자` 기준으로 `ExamParticipant`를 조회한 뒤, 해당 시험이 `RUNNING` 상태일 때만 세션 정보를 반환합니다.
  - 대기 화면에서 사용하던 `examId` 기준과 `/test` 진입 후 세션 복구 기준을 맞출 수 있도록 했습니다.

  ## 배경

  기존 active-session API는 현재 사용자 기준 최신 참가 시험을 조회했습니다.

  이 때문에 참가자가 특정 시험 대기 화면에 있다가 관리자가 시험을 시작한 직후:

  - 대기 화면의 `getExamState(examId)`는 `RUNNING`을 확인
  - `/test` 진입 후 `GET /api/exams/active-session`은 다른 최신 참가 기록을 기준으로 판단
  - `NO_ACTIVE_SESSION`으로 404 반환
  - FE가 세션 없음으로 판단해 입장 화면으로 redirect 되는 문제가 발생할 수 있었습니다.

  ## 테스트

  - `GetActiveSessionUseCaseTest`
    - 시험 ID 기준 활성 세션 조회 성공 케이스 추가
    - 지정 시험 참가 기록이 없을 때 `NO_ACTIVE_SESSION` 예외 케이스 추가
  - `ExamControllerTest`
    - `GET /api/exams/{examId}/active-session` 성공 응답 테스트 추가

  ```bash
  ./gradlew test