### PR TITLE
관리자 통계 및 서버 상태 API 개선

### DIFF
--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/ExamineeBoardResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/ExamineeBoardResponse.java
@@ -3,6 +3,9 @@ package com.yd.vibecode.domain.admin.application.dto.response;
 import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
 import com.yd.vibecode.domain.auth.domain.entity.User;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
 public record ExamineeBoardResponse(
     Long examParticipantId,
     String name,
@@ -10,17 +13,35 @@ public record ExamineeBoardResponse(
     String state,
     Integer tokenLimit,
     Long tokenUsed,
-    Boolean submitted
+    Boolean submitted,
+    Long submissionId,
+    String submissionStatus,
+    BigDecimal totalScore,
+    LocalDateTime submittedAt,
+    LocalDateTime evaluatedAt
 ) {
-    public static ExamineeBoardResponse of(ExamParticipant ep, User p, Boolean submitted) {
+    public static ExamineeBoardResponse of(
+            ExamParticipant ep,
+            User p,
+            boolean submitted,
+            Long submissionId,
+            String submissionStatus,
+            BigDecimal totalScore,
+            LocalDateTime submittedAt,
+            LocalDateTime evaluatedAt) {
         return new ExamineeBoardResponse(
             ep.getId(),
-            p.getName(),
-            maskPhone(p.getPhone()),
+            p != null ? p.getName() : "",
+            p != null ? maskPhone(p.getPhone()) : "",
             ep.getState(),
             ep.getTokenLimit(),
             ep.getTokenUsed().longValue(),
-            submitted
+            submitted,
+            submissionId,
+            submissionStatus,
+            totalScore,
+            submittedAt,
+            evaluatedAt
         );
     }
 

--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/ExamineeBoardResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/ExamineeBoardResponse.java
@@ -16,6 +16,9 @@ public record ExamineeBoardResponse(
     Boolean submitted,
     Long submissionId,
     String submissionStatus,
+    BigDecimal promptScore,
+    BigDecimal perfScore,
+    BigDecimal correctnessScore,
     BigDecimal totalScore,
     LocalDateTime submittedAt,
     LocalDateTime evaluatedAt
@@ -26,6 +29,9 @@ public record ExamineeBoardResponse(
             boolean submitted,
             Long submissionId,
             String submissionStatus,
+            BigDecimal promptScore,
+            BigDecimal perfScore,
+            BigDecimal correctnessScore,
             BigDecimal totalScore,
             LocalDateTime submittedAt,
             LocalDateTime evaluatedAt) {
@@ -39,6 +45,9 @@ public record ExamineeBoardResponse(
             submitted,
             submissionId,
             submissionStatus,
+            promptScore,
+            perfScore,
+            correctnessScore,
             totalScore,
             submittedAt,
             evaluatedAt

--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/SystemStatusResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/SystemStatusResponse.java
@@ -1,0 +1,14 @@
+package com.yd.vibecode.domain.admin.application.dto.response;
+
+import java.util.List;
+
+public record SystemStatusResponse(
+    List<ServiceStatusItem> services
+) {
+    public record ServiceStatusItem(
+        String key,
+        String name,
+        String status,
+        Long latencyMs
+    ) {}
+}

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamineeBoardUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamineeBoardUseCase.java
@@ -5,9 +5,19 @@ import com.yd.vibecode.domain.auth.domain.entity.User;
 import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
 import com.yd.vibecode.domain.exam.domain.repository.ExamParticipantRepository;
 import com.yd.vibecode.domain.auth.domain.repository.UserRepository;
+import com.yd.vibecode.domain.submission.domain.entity.Score;
+import com.yd.vibecode.domain.submission.domain.entity.Submission;
+import com.yd.vibecode.domain.submission.domain.repository.ScoreRepository;
+import com.yd.vibecode.domain.submission.domain.repository.SubmissionRepository;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,29 +28,65 @@ public class GetExamineeBoardUseCase {
 
     private final ExamParticipantRepository examParticipantRepository;
     private final UserRepository userRepository;
+    private final SubmissionRepository submissionRepository;
+    private final ScoreRepository scoreRepository;
 
     @Transactional(readOnly = true)
     public List<ExamineeBoardResponse> execute(Long examId) {
-        // ExamParticipantRepository에 findByExamId가 추가되었다고 가정
         List<ExamParticipant> participants = examParticipantRepository.findAllByExamId(examId);
-        
-        // 참가자 ID 수집
+
         List<Long> participantIds = participants.stream()
             .map(ExamParticipant::getParticipantId)
             .toList();
-            
-        // 참가자 상세 정보 조회
-        Map<Long, User> userMap = userRepository.findAllById(participantIds).stream()
-            .collect(Collectors.toMap(User::getId, p -> p));
 
-        // ExamineeBoardResponse로 매핑
+        Map<Long, User> userMap = userRepository.findAllById(participantIds).stream()
+            .collect(Collectors.toMap(User::getId, Function.identity()));
+
+        List<Submission> submissions = submissionRepository.findByExamId(examId);
+        Map<Long, Submission> submissionByParticipantId = submissions.stream()
+            .collect(Collectors.toMap(Submission::getParticipantId, Function.identity(), (a, b) -> a));
+
+        final Map<Long, Score> scoreBySubmissionId;
+        if (submissions.isEmpty()) {
+            scoreBySubmissionId = Collections.emptyMap();
+        } else {
+            List<Long> submissionIds = submissions.stream().map(Submission::getId).toList();
+            scoreBySubmissionId = scoreRepository.findBySubmissionIdIn(submissionIds).stream()
+                .collect(Collectors.toMap(Score::getSubmissionId, Function.identity(), (a, b) -> a));
+        }
+
         return participants.stream()
             .map(ep -> {
                 User p = userMap.get(ep.getParticipantId());
-                // 참고: 제출 상태는 submission 도메인의 SubmissionRepository가 필요함 (아직 미구현)
-                // submission 도메인 준비 시 추가: submissionRepository.existsByExamIdAndParticipantId(examId, ep.getParticipantId())
-                Boolean submitted = false; 
-                return ExamineeBoardResponse.of(ep, p, submitted);
+                // submissions.participant_id는 원칙적으로 users.id (= exam_participants.participant_id).
+                // 레거시/외부 데이터에서 exam_participants.id가 들어간 경우를 보조 매칭한다.
+                Submission sub = submissionByParticipantId.get(ep.getParticipantId());
+                if (sub == null) {
+                    sub = submissionByParticipantId.get(ep.getId());
+                }
+                boolean submitted = sub != null;
+                Long submissionId = submitted ? sub.getId() : null;
+                String submissionStatus = submitted ? sub.getStatus().name() : null;
+                LocalDateTime submittedAt = submitted ? sub.getCreatedAt() : null;
+                BigDecimal totalScore = null;
+                LocalDateTime evaluatedAt = null;
+                if (submitted) {
+                    Score score = scoreBySubmissionId.get(sub.getId());
+                    if (score != null) {
+                        totalScore = score.getTotalScore();
+                        evaluatedAt = score.getUpdatedAt() != null ? score.getUpdatedAt() : score.getCreatedAt();
+                    }
+                }
+                return ExamineeBoardResponse.of(
+                    ep,
+                    p,
+                    submitted,
+                    submissionId,
+                    submissionStatus,
+                    totalScore,
+                    submittedAt,
+                    evaluatedAt
+                );
             })
             .toList();
     }

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamineeBoardUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamineeBoardUseCase.java
@@ -58,12 +58,7 @@ public class GetExamineeBoardUseCase {
         return participants.stream()
             .map(ep -> {
                 User p = userMap.get(ep.getParticipantId());
-                // submissions.participant_id는 원칙적으로 users.id (= exam_participants.participant_id).
-                // 레거시/외부 데이터에서 exam_participants.id가 들어간 경우를 보조 매칭한다.
                 Submission sub = submissionByParticipantId.get(ep.getParticipantId());
-                if (sub == null) {
-                    sub = submissionByParticipantId.get(ep.getId());
-                }
                 boolean submitted = sub != null;
                 Long submissionId = submitted ? sub.getId() : null;
                 String submissionStatus = submitted ? sub.getStatus().name() : null;

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamineeBoardUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamineeBoardUseCase.java
@@ -63,11 +63,17 @@ public class GetExamineeBoardUseCase {
                 Long submissionId = submitted ? sub.getId() : null;
                 String submissionStatus = submitted ? sub.getStatus().name() : null;
                 LocalDateTime submittedAt = submitted ? sub.getCreatedAt() : null;
+                BigDecimal promptScore = null;
+                BigDecimal perfScore = null;
+                BigDecimal correctnessScore = null;
                 BigDecimal totalScore = null;
                 LocalDateTime evaluatedAt = null;
                 if (submitted) {
                     Score score = scoreBySubmissionId.get(sub.getId());
                     if (score != null) {
+                        promptScore = score.getPromptScore();
+                        perfScore = score.getPerfScore();
+                        correctnessScore = score.getCorrectnessScore();
                         totalScore = score.getTotalScore();
                         evaluatedAt = score.getUpdatedAt() != null ? score.getUpdatedAt() : score.getCreatedAt();
                     }
@@ -78,6 +84,9 @@ public class GetExamineeBoardUseCase {
                     submitted,
                     submissionId,
                     submissionStatus,
+                    promptScore,
+                    perfScore,
+                    correctnessScore,
                     totalScore,
                     submittedAt,
                     evaluatedAt

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetSystemStatusUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetSystemStatusUseCase.java
@@ -1,0 +1,118 @@
+package com.yd.vibecode.domain.admin.application.usecase;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import com.yd.vibecode.domain.admin.application.dto.response.SystemStatusResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.SystemStatusResponse.ServiceStatusItem;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class GetSystemStatusUseCase {
+
+    private static final String STATUS_UP = "UP";
+    private static final String STATUS_DOWN = "DOWN";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final RestTemplate healthRestTemplate;
+    private final String aiServerUrl;
+
+    public GetSystemStatusUseCase(
+            JdbcTemplate jdbcTemplate,
+            @Value("${ai.server.url}") String aiServerUrl) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.aiServerUrl = normalizeBaseUrl(aiServerUrl);
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5_000);
+        factory.setReadTimeout(5_000);
+        this.healthRestTemplate = new RestTemplate(factory);
+    }
+
+    public SystemStatusResponse execute() {
+        List<ServiceStatusItem> services = new ArrayList<>();
+        services.add(checkApiService());
+        services.add(checkDatabaseService());
+        services.add(checkAiGatewayService());
+        return new SystemStatusResponse(services);
+    }
+
+    private ServiceStatusItem checkApiService() {
+        long start = System.nanoTime();
+        long latencyMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+        return new ServiceStatusItem("api", "API 서버", STATUS_UP, latencyMs);
+    }
+
+    private ServiceStatusItem checkDatabaseService() {
+        long start = System.nanoTime();
+        try {
+            Integer result = jdbcTemplate.queryForObject("SELECT 1", Integer.class);
+            long latencyMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+            if (result != null && result == 1) {
+                return new ServiceStatusItem("database", "데이터베이스", STATUS_UP, latencyMs);
+            }
+            log.warn("[SystemStatus] Database ping returned unexpected result: {}", result);
+        } catch (Exception e) {
+            log.error("[SystemStatus] Database health check failed", e);
+        }
+        Long latencyMs = elapsedMsOrNull(start);
+        return new ServiceStatusItem("database", "데이터베이스", STATUS_DOWN, latencyMs);
+    }
+
+    private ServiceStatusItem checkAiGatewayService() {
+        long start = System.nanoTime();
+        String healthUrl = aiServerUrl + "/health";
+        try {
+            @SuppressWarnings("rawtypes")
+            ResponseEntity<Map> response = healthRestTemplate.getForEntity(healthUrl, Map.class);
+            long latencyMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+            if (response.getStatusCode().is2xxSuccessful() && isAiHealthOk(response.getBody())) {
+                return new ServiceStatusItem("ai", "AI 게이트웨이", STATUS_UP, latencyMs);
+            }
+            log.warn("[SystemStatus] AI health check non-success: status={}, body={}",
+                    response.getStatusCode(), response.getBody());
+        } catch (RestClientException e) {
+            log.error("[SystemStatus] AI health check failed: url={}", healthUrl, e);
+        } catch (Exception e) {
+            log.error("[SystemStatus] AI health check unexpected error: url={}", healthUrl, e);
+        }
+        Long latencyMs = elapsedMsOrNull(start);
+        return new ServiceStatusItem("ai", "AI 게이트웨이", STATUS_DOWN, latencyMs);
+    }
+
+    private static boolean isAiHealthOk(Map<?, ?> body) {
+        if (body == null) {
+            return false;
+        }
+        Object status = body.get("status");
+        if (status == null) {
+            return true;
+        }
+        String normalized = status.toString().trim().toLowerCase();
+        return "ok".equals(normalized) || "degraded".equals(normalized);
+    }
+
+    private static Long elapsedMsOrNull(long startNano) {
+        long ms = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNano);
+        return ms >= 0 ? ms : null;
+    }
+
+    private static String normalizeBaseUrl(String url) {
+        if (url == null || url.isBlank()) {
+            return "http://localhost:8000";
+        }
+        String trimmed = url.trim();
+        return trimmed.endsWith("/") ? trimmed.substring(0, trimmed.length() - 1) : trimmed;
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetSystemStatusUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetSystemStatusUseCase.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -24,6 +26,9 @@ public class GetSystemStatusUseCase {
 
     private static final String STATUS_UP = "UP";
     private static final String STATUS_DOWN = "DOWN";
+
+    private static final ParameterizedTypeReference<Map<String, Object>> AI_HEALTH_RESPONSE_TYPE =
+            new ParameterizedTypeReference<>() {};
 
     private final JdbcTemplate jdbcTemplate;
     private final RestTemplate healthRestTemplate;
@@ -49,9 +54,7 @@ public class GetSystemStatusUseCase {
     }
 
     private ServiceStatusItem checkApiService() {
-        long start = System.nanoTime();
-        long latencyMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-        return new ServiceStatusItem("api", "API 서버", STATUS_UP, latencyMs);
+        return new ServiceStatusItem("api", "API 서버", STATUS_UP, null);
     }
 
     private ServiceStatusItem checkDatabaseService() {
@@ -74,8 +77,11 @@ public class GetSystemStatusUseCase {
         long start = System.nanoTime();
         String healthUrl = aiServerUrl + "/health";
         try {
-            @SuppressWarnings("rawtypes")
-            ResponseEntity<Map> response = healthRestTemplate.getForEntity(healthUrl, Map.class);
+            ResponseEntity<Map<String, Object>> response = healthRestTemplate.exchange(
+                    healthUrl,
+                    HttpMethod.GET,
+                    null,
+                    AI_HEALTH_RESPONSE_TYPE);
             long latencyMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
             if (response.getStatusCode().is2xxSuccessful() && isAiHealthOk(response.getBody())) {
                 return new ServiceStatusItem("ai", "AI 게이트웨이", STATUS_UP, latencyMs);
@@ -91,7 +97,7 @@ public class GetSystemStatusUseCase {
         return new ServiceStatusItem("ai", "AI 게이트웨이", STATUS_DOWN, latencyMs);
     }
 
-    private static boolean isAiHealthOk(Map<?, ?> body) {
+    private static boolean isAiHealthOk(Map<String, Object> body) {
         if (body == null) {
             return false;
         }

--- a/src/main/java/com/yd/vibecode/domain/admin/ui/AdminSystemStatusController.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/ui/AdminSystemStatusController.java
@@ -1,0 +1,25 @@
+package com.yd.vibecode.domain.admin.ui;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.yd.vibecode.domain.admin.application.dto.response.SystemStatusResponse;
+import com.yd.vibecode.domain.admin.application.usecase.GetSystemStatusUseCase;
+import com.yd.vibecode.global.common.BaseResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/system-status")
+public class AdminSystemStatusController {
+
+    private final GetSystemStatusUseCase getSystemStatusUseCase;
+
+    @GetMapping
+    public BaseResponse<SystemStatusResponse> getSystemStatus() {
+        SystemStatusResponse response = getSystemStatusUseCase.execute();
+        return BaseResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ActiveSessionResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ActiveSessionResponse.java
@@ -9,6 +9,7 @@ import com.yd.vibecode.domain.exam.domain.entity.ExamState;
 public record ActiveSessionResponse(
     Long examId,
     Long examParticipantId,
+    Long participantId,
     Long assignedProblemId,
     Long specId,
     ExamState examState,
@@ -22,6 +23,7 @@ public record ActiveSessionResponse(
         return new ActiveSessionResponse(
             exam.getId(),
             participant.getId(),
+            participant.getParticipantId(),
             participant.getAssignedProblemId(),
             participant.getSpecId(),
             exam.getState(),

--- a/src/main/java/com/yd/vibecode/domain/submission/application/dto/response/AdminSubmissionDetailResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/dto/response/AdminSubmissionDetailResponse.java
@@ -1,6 +1,10 @@
 package com.yd.vibecode.domain.submission.application.dto.response;
 
+import java.util.List;
+
+import com.yd.vibecode.domain.submission.domain.entity.RunGroup;
 import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
+import com.yd.vibecode.domain.submission.domain.entity.Verdict;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -32,6 +36,28 @@ public record AdminSubmissionDetailResponse(
         SubmissionDetailResponse.ScoreInfo score,
 
         @Schema(description = "AI/채점 루브릭 JSON (민감, scores.rubric_json)")
-        String rubricJson
+        String rubricJson,
+
+        @Schema(description = "개별 테스트 케이스 실행 결과 (submission_runs, 관리자 전용)")
+        List<CaseRunInfo> runs
 ) {
+
+    @Schema(description = "단일 테스트 케이스 실행 결과")
+    public record CaseRunInfo(
+            @Schema(description = "케이스 인덱스", example = "0")
+            Integer caseIndex,
+
+            @Schema(description = "테스트 그룹")
+            RunGroup grp,
+
+            @Schema(description = "판정")
+            Verdict verdict,
+
+            @Schema(description = "실행 시간(ms)", example = "120")
+            Integer timeMs,
+
+            @Schema(description = "메모리(KB)", example = "2048")
+            Integer memKb
+    ) {
+    }
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/application/dto/response/AdminSubmissionDetailResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/dto/response/AdminSubmissionDetailResponse.java
@@ -1,0 +1,37 @@
+package com.yd.vibecode.domain.submission.application.dto.response;
+
+import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 관리자 전용 제출 상세 (제출 코드·루브릭 JSON 포함).
+ * 일반 {@link SubmissionDetailResponse}에는 민감 필드를 넣지 않는다.
+ */
+@Schema(description = "관리자 전용 제출 상세 응답")
+public record AdminSubmissionDetailResponse(
+        @Schema(description = "제출 ID", example = "1")
+        Long submissionId,
+
+        @Schema(description = "제출 상태")
+        SubmissionStatus status,
+
+        @Schema(description = "언어/런타임", example = "python3.11")
+        String lang,
+
+        @Schema(description = "제출 소스 코드 본문 (민감)")
+        String codeInline,
+
+        @Schema(description = "실행 메트릭")
+        SubmissionDetailResponse.MetricsInfo metrics,
+
+        @Schema(description = "테스트 케이스 그룹별 집계")
+        SubmissionDetailResponse.TestCaseInfo tc,
+
+        @Schema(description = "채점 점수")
+        SubmissionDetailResponse.ScoreInfo score,
+
+        @Schema(description = "AI/채점 루브릭 JSON (민감, scores.rubric_json)")
+        String rubricJson
+) {
+}

--- a/src/main/java/com/yd/vibecode/domain/submission/application/service/SubmissionDetailAssembler.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/service/SubmissionDetailAssembler.java
@@ -1,0 +1,107 @@
+package com.yd.vibecode.domain.submission.application.service;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse;
+import com.yd.vibecode.domain.submission.domain.entity.RunGroup;
+import com.yd.vibecode.domain.submission.domain.entity.Score;
+import com.yd.vibecode.domain.submission.domain.entity.Submission;
+import com.yd.vibecode.domain.submission.domain.entity.SubmissionRun;
+import com.yd.vibecode.domain.submission.domain.entity.Verdict;
+
+/**
+ * 제출 상세 응답의 metrics / tc / score 집계 (공용 상세·관리자 상세 공통).
+ */
+@Component
+public class SubmissionDetailAssembler {
+
+    public SubmissionDetailResponse toResponse(Submission submission,
+                                               List<SubmissionRun> runs,
+                                               Score score) {
+        SubmissionDetailResponse.MetricsInfo metrics = calculateMetrics(submission, runs);
+        SubmissionDetailResponse.TestCaseInfo tc = calculateTestCaseInfo(runs);
+        SubmissionDetailResponse.ScoreInfo scoreInfo = score != null
+                ? new SubmissionDetailResponse.ScoreInfo(
+                        score.getPromptScore(),
+                        score.getPerfScore(),
+                        score.getCorrectnessScore(),
+                        score.getTotalScore())
+                : new SubmissionDetailResponse.ScoreInfo(
+                        BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);
+
+        return new SubmissionDetailResponse(
+                submission.getId(),
+                submission.getStatus(),
+                submission.getLang(),
+                metrics,
+                tc,
+                scoreInfo);
+    }
+
+    private SubmissionDetailResponse.MetricsInfo calculateMetrics(Submission submission,
+                                                                  List<SubmissionRun> runs) {
+        List<Integer> times = runs.stream()
+                .map(SubmissionRun::getTimeMs)
+                .filter(t -> t != null)
+                .sorted()
+                .toList();
+
+        Integer timeMsMedian = times.isEmpty() ? null
+                : times.get(times.size() / 2);
+
+        Integer memKbPeak = runs.stream()
+                .map(SubmissionRun::getMemKb)
+                .filter(m -> m != null)
+                .max(Integer::compareTo)
+                .orElse(null);
+
+        return new SubmissionDetailResponse.MetricsInfo(
+                timeMsMedian,
+                memKbPeak,
+                submission.getCodeLoc());
+    }
+
+    private SubmissionDetailResponse.TestCaseInfo calculateTestCaseInfo(List<SubmissionRun> runs) {
+        Map<RunGroup, List<SubmissionRun>> groupedRuns = runs.stream()
+                .collect(Collectors.groupingBy(SubmissionRun::getGrp));
+
+        List<SubmissionDetailResponse.GroupInfo> groups = new ArrayList<>();
+        double totalWeightedPass = 0.0;
+        double totalWeight = 0.0;
+
+        Map<RunGroup, Double> weights = Map.of(
+                RunGroup.SAMPLE, 0.1,
+                RunGroup.PUBLIC, 0.3,
+                RunGroup.PRIVATE, 0.6);
+
+        for (RunGroup group : RunGroup.values()) {
+            List<SubmissionRun> groupRuns = groupedRuns.getOrDefault(group, List.of());
+            if (groupRuns.isEmpty()) {
+                continue;
+            }
+
+            int total = groupRuns.size();
+            int pass = (int) groupRuns.stream()
+                    .filter(r -> r.getVerdict() == Verdict.AC)
+                    .count();
+
+            double weight = weights.getOrDefault(group, 0.0);
+            double passRate = total > 0 ? (double) pass / total : 0.0;
+
+            groups.add(new SubmissionDetailResponse.GroupInfo(group, pass, total, weight));
+
+            totalWeightedPass += passRate * weight;
+            totalWeight += weight;
+        }
+
+        double passRateWeighted = totalWeight > 0 ? totalWeightedPass / totalWeight : 0.0;
+
+        return new SubmissionDetailResponse.TestCaseInfo(passRateWeighted, groups);
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/submission/application/usecase/GetAdminSubmissionDetailUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/usecase/GetAdminSubmissionDetailUseCase.java
@@ -1,5 +1,6 @@
 package com.yd.vibecode.domain.submission.application.usecase;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -38,6 +39,18 @@ public class GetAdminSubmissionDetailUseCase {
         SubmissionDetailResponse base = submissionDetailAssembler.toResponse(submission, runs, score);
         String rubricJson = score != null ? score.getRubricJson() : null;
 
+        List<AdminSubmissionDetailResponse.CaseRunInfo> caseRuns = runs.stream()
+                .sorted(Comparator.comparing(
+                        SubmissionRun::getCaseIndex,
+                        Comparator.nullsLast(Integer::compareTo)))
+                .map(r -> new AdminSubmissionDetailResponse.CaseRunInfo(
+                        r.getCaseIndex(),
+                        r.getGrp(),
+                        r.getVerdict(),
+                        r.getTimeMs(),
+                        r.getMemKb()))
+                .toList();
+
         return new AdminSubmissionDetailResponse(
                 submission.getId(),
                 base.status(),
@@ -46,6 +59,7 @@ public class GetAdminSubmissionDetailUseCase {
                 base.metrics(),
                 base.tc(),
                 base.score(),
-                rubricJson);
+                rubricJson,
+                caseRuns);
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/application/usecase/GetAdminSubmissionDetailUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/usecase/GetAdminSubmissionDetailUseCase.java
@@ -6,6 +6,8 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
 import com.yd.vibecode.domain.submission.application.dto.response.AdminSubmissionDetailResponse;
 import com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse;
 import com.yd.vibecode.domain.submission.application.service.SubmissionDetailAssembler;
@@ -15,6 +17,8 @@ import com.yd.vibecode.domain.submission.domain.entity.SubmissionRun;
 import com.yd.vibecode.domain.submission.domain.repository.ScoreRepository;
 import com.yd.vibecode.domain.submission.domain.repository.SubmissionRunRepository;
 import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,13 +29,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class GetAdminSubmissionDetailUseCase {
 
+    private final AdminService adminService;
     private final SubmissionService submissionService;
     private final SubmissionRunRepository submissionRunRepository;
     private final ScoreRepository scoreRepository;
     private final SubmissionDetailAssembler submissionDetailAssembler;
 
     @Transactional(readOnly = true)
-    public AdminSubmissionDetailResponse execute(Long submissionId) {
+    public AdminSubmissionDetailResponse execute(Long adminUserId, Long submissionId) {
+        validateAdminAccess(adminUserId);
         Submission submission = submissionService.findById(submissionId);
         List<SubmissionRun> runs = submissionRunRepository.findBySubmissionId(submissionId);
         Score score = scoreRepository.findBySubmissionId(submissionId).orElse(null);
@@ -61,5 +67,19 @@ public class GetAdminSubmissionDetailUseCase {
                 base.score(),
                 rubricJson,
                 caseRuns);
+    }
+
+    /**
+     * 요청자가 활성화된 ADMIN/MASTER 관리자인지 DB 기준으로 검증한다.
+     * (HTTP {@code /api/admin/**} 역할 검사와 별도로 UseCase 방어층)
+     */
+    private void validateAdminAccess(Long adminUserId) {
+        Admin admin = adminService.findById(adminUserId);
+        if (!Boolean.TRUE.equals(admin.getIsActive())) {
+            throw new RestApiException(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE);
+        }
+        if (!admin.isAdmin() && !admin.isMaster()) {
+            throw new RestApiException(AuthErrorStatus.FORBIDDEN);
+        }
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/application/usecase/GetAdminSubmissionDetailUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/usecase/GetAdminSubmissionDetailUseCase.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.yd.vibecode.domain.submission.application.dto.response.AdminSubmissionDetailResponse;
 import com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse;
 import com.yd.vibecode.domain.submission.application.service.SubmissionDetailAssembler;
 import com.yd.vibecode.domain.submission.domain.entity.Score;
@@ -17,11 +18,11 @@ import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 제출 상세 조회 UseCase (일반 인증 사용자용 — 코드·루브릭 미포함).
+ * 관리자 전용 제출 상세 조회 (코드 본문·rubricJson 포함).
  */
 @Service
 @RequiredArgsConstructor
-public class GetSubmissionDetailUseCase {
+public class GetAdminSubmissionDetailUseCase {
 
     private final SubmissionService submissionService;
     private final SubmissionRunRepository submissionRunRepository;
@@ -29,10 +30,22 @@ public class GetSubmissionDetailUseCase {
     private final SubmissionDetailAssembler submissionDetailAssembler;
 
     @Transactional(readOnly = true)
-    public SubmissionDetailResponse execute(Long submissionId) {
+    public AdminSubmissionDetailResponse execute(Long submissionId) {
         Submission submission = submissionService.findById(submissionId);
         List<SubmissionRun> runs = submissionRunRepository.findBySubmissionId(submissionId);
         Score score = scoreRepository.findBySubmissionId(submissionId).orElse(null);
-        return submissionDetailAssembler.toResponse(submission, runs, score);
+
+        SubmissionDetailResponse base = submissionDetailAssembler.toResponse(submission, runs, score);
+        String rubricJson = score != null ? score.getRubricJson() : null;
+
+        return new AdminSubmissionDetailResponse(
+                submission.getId(),
+                base.status(),
+                base.lang(),
+                submission.getCodeInline(),
+                base.metrics(),
+                base.tc(),
+                base.score(),
+                rubricJson);
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/application/usecase/GetSubmissionDetailUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/usecase/GetSubmissionDetailUseCase.java
@@ -1,6 +1,7 @@
 package com.yd.vibecode.domain.submission.application.usecase;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +14,8 @@ import com.yd.vibecode.domain.submission.domain.entity.SubmissionRun;
 import com.yd.vibecode.domain.submission.domain.repository.ScoreRepository;
 import com.yd.vibecode.domain.submission.domain.repository.SubmissionRunRepository;
 import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,8 +32,11 @@ public class GetSubmissionDetailUseCase {
     private final SubmissionDetailAssembler submissionDetailAssembler;
 
     @Transactional(readOnly = true)
-    public SubmissionDetailResponse execute(Long submissionId) {
+    public SubmissionDetailResponse execute(Long currentUserId, Long submissionId) {
         Submission submission = submissionService.findById(submissionId);
+        if (!Objects.equals(submission.getParticipantId(), currentUserId)) {
+            throw new RestApiException(GlobalErrorStatus._FORBIDDEN);
+        }
         List<SubmissionRun> runs = submissionRunRepository.findBySubmissionId(submissionId);
         Score score = scoreRepository.findBySubmissionId(submissionId).orElse(null);
         return submissionDetailAssembler.toResponse(submission, runs, score);

--- a/src/main/java/com/yd/vibecode/domain/submission/application/usecase/SubmitUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/usecase/SubmitUseCase.java
@@ -3,12 +3,12 @@ package com.yd.vibecode.domain.submission.application.usecase;
 import com.yd.vibecode.domain.submission.domain.entity.Submission;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import com.yd.vibecode.domain.chat.domain.service.PromptSessionService;
-import com.yd.vibecode.domain.chat.infrastructure.AIChatService;
 import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
 import com.yd.vibecode.domain.exam.domain.service.ExamParticipantService;
+import com.yd.vibecode.domain.problem.domain.entity.ProblemSpec;
+import com.yd.vibecode.domain.problem.domain.service.ProblemSpecService;
 import com.yd.vibecode.domain.submission.application.dto.request.AISubmitEvaluationRequest;
 import com.yd.vibecode.domain.submission.application.dto.request.SubmitRequest;
 import com.yd.vibecode.domain.submission.application.dto.response.SubmitResponse;
@@ -16,6 +16,7 @@ import com.yd.vibecode.domain.submission.domain.service.OutboxEventService;
 import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
 import com.yd.vibecode.global.exception.RestApiException;
 import com.yd.vibecode.global.exception.code.status.ProblemErrorStatus;
+import com.yd.vibecode.global.exception.code.status.SubmissionErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,7 @@ public class SubmitUseCase {
 
     private final ExamParticipantService examParticipantService;
     private final SubmissionService submissionService;
+    private final ProblemSpecService problemSpecService;
     private final PromptSessionService promptSessionService;
     private final OutboxEventService outboxEventService;
 
@@ -43,6 +45,16 @@ public class SubmitUseCase {
         
         if (examParticipant == null || examParticipant.getSpecId() == null) {
             throw new RestApiException(ProblemErrorStatus.NO_ASSIGNED_PROBLEM);
+        }
+
+        if (submissionService.existsByExamIdAndParticipantId(examId, userId)) {
+            throw new RestApiException(SubmissionErrorStatus.ALREADY_SUBMITTED);
+        }
+
+        Long problemId = examParticipant.getAssignedProblemId();
+        if (problemId == null) {
+            ProblemSpec spec = problemSpecService.findBySpecId(examParticipant.getSpecId());
+            problemId = spec.getProblemId();
         }
 
         // 2. 제출 생성 및 Redis Queue enqueue
@@ -62,7 +74,7 @@ public class SubmitUseCase {
         AISubmitEvaluationRequest aiRequest = new AISubmitEvaluationRequest(
                 examId,
                 userId,  // participantId
-                examParticipant.getAssignedProblemId(),
+                problemId,
                 examParticipant.getSpecId(),
                 request.code(),
                 request.lang(),

--- a/src/main/java/com/yd/vibecode/domain/submission/domain/repository/ScoreRepository.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/domain/repository/ScoreRepository.java
@@ -4,9 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.yd.vibecode.domain.submission.domain.entity.Score;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface ScoreRepository extends JpaRepository<Score, Long> {
 
     Optional<Score> findBySubmissionId(Long submissionId);
+
+    List<Score> findBySubmissionIdIn(Collection<Long> submissionIds);
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/domain/repository/SubmissionRepository.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/domain/repository/SubmissionRepository.java
@@ -12,7 +12,9 @@ import java.util.Optional;
 public interface SubmissionRepository extends JpaRepository<Submission, Long> {
 
     Optional<Submission> findByExamIdAndParticipantId(Long examId, Long participantId);
-    
+
+    boolean existsByExamIdAndParticipantId(Long examId, Long participantId);
+
     List<Submission> findByExamId(Long examId);
     
     List<Submission> findByParticipantId(Long participantId);

--- a/src/main/java/com/yd/vibecode/domain/submission/domain/service/SubmissionService.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/domain/service/SubmissionService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
 
 /**
  * SubmissionService
@@ -37,6 +38,16 @@ public class SubmissionService {
     public Submission findById(Long id) {
         return submissionRepository.findById(id)
                 .orElseThrow(() -> new RestApiException(SubmissionErrorStatus.SUBMISSION_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByExamIdAndParticipantId(Long examId, Long participantId) {
+        return submissionRepository.findByExamIdAndParticipantId(examId, participantId).isPresent();
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Submission> findOptionalByExamIdAndParticipantId(Long examId, Long participantId) {
+        return submissionRepository.findByExamIdAndParticipantId(examId, participantId);
     }
 
     /**

--- a/src/main/java/com/yd/vibecode/domain/submission/domain/service/SubmissionService.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/domain/service/SubmissionService.java
@@ -42,7 +42,7 @@ public class SubmissionService {
 
     @Transactional(readOnly = true)
     public boolean existsByExamIdAndParticipantId(Long examId, Long participantId) {
-        return submissionRepository.findByExamIdAndParticipantId(examId, participantId).isPresent();
+        return submissionRepository.existsByExamIdAndParticipantId(examId, participantId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/yd/vibecode/domain/submission/infrastructure/SseEmitterRegistry.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/infrastructure/SseEmitterRegistry.java
@@ -1,8 +1,11 @@
 package com.yd.vibecode.domain.submission.infrastructure;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -11,11 +14,11 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * SSE Emitter 레지스트리
- * submissionId별 SseEmitter를 관리한다.
+ * submissionId별로 여러 {@link SseEmitter}를 둘 수 있다 (관리자·응시자 동시 구독).
  *
- * - 연결 수립: register(submissionId) → SseEmitter 반환
- * - 이벤트 발행: send(submissionId, eventName, data) — IOException 시 SseDeliveryException throw
- * - 연결 종료: complete(submissionId)
+ * - 연결 수립: register(submissionId) → SseEmitter 반환 후 목록에 추가
+ * - 이벤트 발행: send(submissionId, eventName, data) — 등록된 모든 에미터에 브로드캐스트
+ * - 연결 종료: complete(submissionId) — 해당 제출의 모든 에미터 종료
  *
  * 주의: 인메모리 단일 서버 전제. 서버 재시작 시 연결 초기화됨.
  */
@@ -26,70 +29,93 @@ public class SseEmitterRegistry {
     // SSE 타임아웃: 10분 (채점은 최대 수 분 소요 전제)
     private static final long SSE_TIMEOUT_MS = 10 * 60 * 1000L;
 
-    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<Long, CopyOnWriteArrayList<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     /**
      * submissionId에 대한 새 SseEmitter를 생성하고 등록한다.
-     * 콜백에는 2-arg remove(submissionId, emitter)를 사용하여
-     * 교체 직후 새 에미터가 의도치 않게 제거되는 race condition을 방지한다.
+     * 기존 구독이 있어도 유지하며, 동일 제출에 대해 여러 클라이언트(관리자/응시자)가 동시에 구독할 수 있다.
      */
     public SseEmitter register(Long submissionId) {
         SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MS);
 
-        emitter.onCompletion(() -> {
-            emitters.remove(submissionId, emitter);
-            log.debug("SSE emitter completed: submissionId={}", submissionId);
-        });
-        emitter.onTimeout(() -> {
-            emitters.remove(submissionId, emitter);
-            log.warn("SSE emitter timed out: submissionId={}", submissionId);
-        });
-        emitter.onError(e -> {
-            emitters.remove(submissionId, emitter);
-            log.error("SSE emitter error: submissionId={}", submissionId, e);
-        });
+        Runnable removeSelf = () -> removeEmitter(submissionId, emitter);
+        emitter.onCompletion(removeSelf);
+        emitter.onTimeout(removeSelf);
+        emitter.onError(e -> removeSelf.run());
 
-        SseEmitter old = emitters.put(submissionId, emitter);
-        if (old != null) {
-            old.complete();
-        }
+        CopyOnWriteArrayList<SseEmitter> list =
+                emitters.computeIfAbsent(submissionId, k -> new CopyOnWriteArrayList<>());
+        list.add(emitter);
 
-        log.info("SSE emitter registered: submissionId={}", submissionId);
+        log.info("SSE emitter registered: submissionId={}, activeCount={}", submissionId, list.size());
         return emitter;
+    }
+
+    private void removeEmitter(Long submissionId, SseEmitter emitter) {
+        emitters.computeIfPresent(submissionId, (id, list) -> {
+            list.remove(emitter);
+            return list.isEmpty() ? null : list;
+        });
+        log.debug("SSE emitter removed: submissionId={}", submissionId);
     }
 
     /**
      * submissionId에 이벤트를 전송한다.
      *
-     * @throws SseDeliveryException 에미터가 존재하지만 I/O 오류로 전송 실패 시 (재시도 트리거)
-     *         에미터가 없는 경우(클라이언트 연결 없음)는 예외 없이 리턴 (재시도 불필요)
+     * @throws SseDeliveryException 연결된 모든 에미터에 대한 전송이 I/O 오류로 실패한 경우 (재시도 트리거)
+     *         에미터가 없는 경우는 예외 없이 리턴
      */
     public void send(Long submissionId, String eventName, Object data) {
-        SseEmitter emitter = emitters.get(submissionId);
-        if (emitter == null) {
+        CopyOnWriteArrayList<SseEmitter> list = emitters.get(submissionId);
+        if (list == null || list.isEmpty()) {
             log.debug("No SSE emitter for submissionId={}, client disconnected", submissionId);
             return;
         }
 
-        try {
-            emitter.send(SseEmitter.event()
-                    .name(eventName)
-                    .data(data));
-        } catch (IOException e) {
-            emitters.remove(submissionId, emitter);
-            // 재시도 가능한 실패 → SseDeliveryException throw
-            throw new SseDeliveryException(submissionId, eventName, e);
+        List<SseEmitter> snapshot = new ArrayList<>(list);
+        int attempted = 0;
+        int failures = 0;
+        IOException firstFailure = null;
+
+        for (SseEmitter emitter : snapshot) {
+            if (!list.contains(emitter)) {
+                continue;
+            }
+            attempted++;
+            try {
+                emitter.send(SseEmitter.event()
+                        .name(eventName)
+                        .data(data));
+            } catch (IOException e) {
+                failures++;
+                if (firstFailure == null) {
+                    firstFailure = e;
+                }
+                list.remove(emitter);
+                log.warn("SSE send failed, removing emitter: submissionId={}, event={}", submissionId, eventName, e);
+            }
+        }
+
+        if (attempted > 0 && failures == attempted && firstFailure != null) {
+            throw new SseDeliveryException(submissionId, eventName, firstFailure);
         }
     }
 
     /**
-     * 채점 완료 후 스트림을 종료한다.
+     * 채점 완료 후 해당 제출의 모든 스트림을 종료한다.
      */
     public void complete(Long submissionId) {
-        SseEmitter emitter = emitters.remove(submissionId);
-        if (emitter != null) {
-            emitter.complete();
-            log.info("SSE emitter completed by server: submissionId={}", submissionId);
+        CopyOnWriteArrayList<SseEmitter> list = emitters.remove(submissionId);
+        if (list == null || list.isEmpty()) {
+            return;
         }
+        for (SseEmitter emitter : new ArrayList<>(list)) {
+            try {
+                emitter.complete();
+            } catch (Exception e) {
+                log.debug("SSE complete ignored: {}", e.getMessage());
+            }
+        }
+        log.info("SSE all emitters completed: submissionId={}, count={}", submissionId, list.size());
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionDetailController.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionDetailController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.yd.vibecode.domain.submission.application.dto.response.AdminSubmissionDetailResponse;
 import com.yd.vibecode.domain.submission.application.usecase.GetAdminSubmissionDetailUseCase;
+import com.yd.vibecode.global.annotation.CurrentUser;
 import com.yd.vibecode.global.common.BaseResponse;
 import com.yd.vibecode.global.swagger.AdminSubmissionDetailApi;
 
@@ -27,8 +28,10 @@ public class AdminSubmissionDetailController implements AdminSubmissionDetailApi
     @Override
     @GetMapping("/{submissionId}")
     public BaseResponse<AdminSubmissionDetailResponse> getAdminSubmissionDetail(
-            @PathVariable Long submissionId) {
-        AdminSubmissionDetailResponse response = getAdminSubmissionDetailUseCase.execute(submissionId);
+            @PathVariable Long submissionId,
+            @CurrentUser Long adminUserId) {
+        AdminSubmissionDetailResponse response =
+                getAdminSubmissionDetailUseCase.execute(adminUserId, submissionId);
         return BaseResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionDetailController.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionDetailController.java
@@ -1,0 +1,34 @@
+package com.yd.vibecode.domain.submission.ui;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.yd.vibecode.domain.submission.application.dto.response.AdminSubmissionDetailResponse;
+import com.yd.vibecode.domain.submission.application.usecase.GetAdminSubmissionDetailUseCase;
+import com.yd.vibecode.global.common.BaseResponse;
+import com.yd.vibecode.global.swagger.AdminSubmissionDetailApi;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 관리자 전용 제출 상세 (민감 필드 포함).
+ * <p>
+ * 보안: {@code /api/admin/**} 는 SecurityConfig 에서 ADMIN/MASTER 만 허용.
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/submissions")
+public class AdminSubmissionDetailController implements AdminSubmissionDetailApi {
+
+    private final GetAdminSubmissionDetailUseCase getAdminSubmissionDetailUseCase;
+
+    @Override
+    @GetMapping("/{submissionId}")
+    public BaseResponse<AdminSubmissionDetailResponse> getAdminSubmissionDetail(
+            @PathVariable Long submissionId) {
+        AdminSubmissionDetailResponse response = getAdminSubmissionDetailUseCase.execute(submissionId);
+        return BaseResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/submission/ui/ExamineeSubmissionStreamController.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/ui/ExamineeSubmissionStreamController.java
@@ -1,0 +1,50 @@
+package com.yd.vibecode.domain.submission.ui;
+
+import java.util.Objects;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.yd.vibecode.domain.submission.domain.entity.Submission;
+import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
+import com.yd.vibecode.domain.submission.infrastructure.SseEmitterRegistry;
+import com.yd.vibecode.global.annotation.CurrentUser;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
+import com.yd.vibecode.global.swagger.SubmissionStreamApi;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 응시자 전용 채점 SSE.
+ * <p>
+ * {@code GET /api/submissions/{submissionId}/stream} — 인증된 사용자만 접근하며,
+ * 제출의 {@code participantId}가 액세스 토큰의 user id와 일치할 때만 연결한다.
+ * <p>
+ * 이벤트 페이로드는 {@link com.yd.vibecode.domain.submission.infrastructure.SseRetryExecutor}가
+ * 관리자 스트림과 동일하게 보내는 범위(case_result, final_score)로 제한된다(코드·루브릭 미포함).
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/submissions")
+public class ExamineeSubmissionStreamController implements SubmissionStreamApi {
+
+    private final SubmissionService submissionService;
+    private final SseEmitterRegistry sseEmitterRegistry;
+
+    @Override
+    @GetMapping(value = "/{submissionId}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamScoringResultForExaminee(
+            @PathVariable Long submissionId,
+            @CurrentUser Long currentUserId) {
+        Submission submission = submissionService.findById(submissionId);
+        if (!Objects.equals(submission.getParticipantId(), currentUserId)) {
+            throw new RestApiException(GlobalErrorStatus._FORBIDDEN);
+        }
+        return sseEmitterRegistry.register(submissionId);
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/submission/ui/SubmissionController.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/ui/SubmissionController.java
@@ -24,8 +24,8 @@ import lombok.RequiredArgsConstructor;
 /**
  * Submission Controller
  * - POST /api/exams/{examId}/submissions: 코드 제출
- * - GET /api/submissions/{submissionId}: 제출 상세 조회 (로그인 사용자 공통, 제출 코드·루브릭 미포함)
- *   보안: {@code SecurityConfig} 상 인증만 필요하며 소유자 검증은 없음. 민감 데이터는
+ * - GET /api/submissions/{submissionId}: 제출 상세 조회 (본인 제출만, 제출 코드·루브릭 미포함)
+ *   보안: {@code participantId}가 액세스 토큰 user id와 일치할 때만 조회. 민감 데이터는
  *   {@code GET /api/admin/submissions/{id}} (ADMIN/MASTER)를 사용한다.
  */
 @RestController
@@ -48,8 +48,10 @@ public class SubmissionController implements SubmissionApi {
 
     @GetMapping("/submissions/{submissionId}")
     public BaseResponse<SubmissionDetailResponse> getSubmissionDetail(
-            @PathVariable Long submissionId) {
-        SubmissionDetailResponse response = getSubmissionDetailUseCase.execute(submissionId);
+            @PathVariable Long submissionId,
+            @CurrentUser Long currentUserId) {
+        SubmissionDetailResponse response =
+                getSubmissionDetailUseCase.execute(currentUserId, submissionId);
         return BaseResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/ui/SubmissionController.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/ui/SubmissionController.java
@@ -24,7 +24,9 @@ import lombok.RequiredArgsConstructor;
 /**
  * Submission Controller
  * - POST /api/exams/{examId}/submissions: 코드 제출
- * - GET /api/submissions/{submissionId}: 제출 상세 조회
+ * - GET /api/submissions/{submissionId}: 제출 상세 조회 (로그인 사용자 공통, 제출 코드·루브릭 미포함)
+ *   보안: {@code SecurityConfig} 상 인증만 필요하며 소유자 검증은 없음. 민감 데이터는
+ *   {@code GET /api/admin/submissions/{id}} (ADMIN/MASTER)를 사용한다.
  */
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/yd/vibecode/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/yd/vibecode/global/exception/ExceptionAdvice.java
@@ -3,12 +3,14 @@ package com.yd.vibecode.global.exception;
 import com.yd.vibecode.global.common.BaseResponse;
 import com.yd.vibecode.global.exception.code.BaseCode;
 import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
+import com.yd.vibecode.global.exception.code.status.SubmissionErrorStatus;
 import jakarta.validation.ConstraintViolationException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -42,6 +44,25 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 e.getErrorCode().getCode(), e.getErrorCode().getMessage());
         BaseCode errorCode = e.getErrorCode();
         return handleExceptionInternal(errorCode);
+    }
+
+    /**
+     * 동일 시험·참가자에 대한 제출은 DB 유니크(exam_id, participant_id)로 한 건만 허용된다.
+     * 경쟁 조건 등으로 사전 검사를 통과한 뒤에도 위반이 나면 SUB002로 응답한다.
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<BaseResponse<String>> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+        Throwable root = e.getMostSpecificCause();
+        String msg = root != null ? root.getMessage() : e.getMessage();
+        String lower = msg != null ? msg.toLowerCase() : "";
+        if (lower.contains("submissions")
+                || (lower.contains("exam_id") && lower.contains("participant_id"))
+                || (lower.contains("duplicate") && lower.contains("submission"))) {
+            log.warn("[handleDataIntegrityViolation] duplicate submission constraint: {}", msg);
+            return handleExceptionInternal(SubmissionErrorStatus.ALREADY_SUBMITTED.getCode());
+        }
+        log.error("[handleDataIntegrityViolation] unmapped constraint: {}", msg, e);
+        return handleExceptionInternal(GlobalErrorStatus._EXIST_ENTITY.getCode());
     }
 
     /*

--- a/src/main/java/com/yd/vibecode/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/yd/vibecode/global/exception/ExceptionAdvice.java
@@ -52,17 +52,52 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<BaseResponse<String>> handleDataIntegrityViolation(DataIntegrityViolationException e) {
-        Throwable root = e.getMostSpecificCause();
-        String msg = root != null ? root.getMessage() : e.getMessage();
-        String lower = msg != null ? msg.toLowerCase() : "";
-        if (lower.contains("submissions")
-                || (lower.contains("exam_id") && lower.contains("participant_id"))
-                || (lower.contains("duplicate") && lower.contains("submission"))) {
-            log.warn("[handleDataIntegrityViolation] duplicate submission constraint: {}", msg);
+        if (isDuplicateSubmissionConstraintViolation(e)) {
+            log.warn("[handleDataIntegrityViolation] duplicate submission (exam_id, participant_id): {}",
+                    e.getMostSpecificCause() != null ? e.getMostSpecificCause().getMessage() : e.getMessage());
             return handleExceptionInternal(SubmissionErrorStatus.ALREADY_SUBMITTED.getCode());
         }
+        String msg = e.getMostSpecificCause() != null ? e.getMostSpecificCause().getMessage() : e.getMessage();
         log.error("[handleDataIntegrityViolation] unmapped constraint: {}", msg, e);
         return handleExceptionInternal(GlobalErrorStatus._EXIST_ENTITY.getCode());
+    }
+
+    /**
+     * submissions 테이블의 (exam_id, participant_id) 유니크 위반만 SUB002로 매핑한다.
+     * submissions 테이블명·FK·NOT NULL 등 다른 무결성 오류는 제외한다.
+     */
+    static boolean isDuplicateSubmissionConstraintViolation(DataIntegrityViolationException e) {
+        String text = extractConstraintViolationText(e).toLowerCase();
+        if (text.isBlank()) {
+            return false;
+        }
+        if (!text.contains("exam_id") || !text.contains("participant_id")) {
+            return false;
+        }
+        return text.contains("duplicate")
+                || text.contains("unique constraint")
+                || text.contains("unique key")
+                || text.contains("violates unique")
+                || (text.contains("unique") && text.contains("constraint"))
+                || text.contains("already exists");
+    }
+
+    private static String extractConstraintViolationText(DataIntegrityViolationException e) {
+        StringBuilder sb = new StringBuilder();
+        Throwable current = e;
+        while (current != null) {
+            if (current.getMessage() != null) {
+                sb.append(current.getMessage()).append(' ');
+            }
+            if (current instanceof org.hibernate.exception.ConstraintViolationException hibernateCve) {
+                String constraintName = hibernateCve.getConstraintName();
+                if (constraintName != null) {
+                    sb.append(constraintName).append(' ');
+                }
+            }
+            current = current.getCause();
+        }
+        return sb.toString().trim();
     }
 
     /*

--- a/src/main/java/com/yd/vibecode/global/swagger/AdminSubmissionDetailApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/AdminSubmissionDetailApi.java
@@ -28,10 +28,15 @@ public interface AdminSubmissionDetailApi extends BaseApi {
                     description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = AdminSubmissionDetailResponse.class))),
             @ApiResponse(
+                    responseCode = "403",
+                    description = "관리자 권한 없음 또는 비활성 계정",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(
                     responseCode = "404",
                     description = "제출을 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     BaseResponse<AdminSubmissionDetailResponse> getAdminSubmissionDetail(
-            @Parameter(description = "제출 ID", example = "1") Long submissionId);
+            @Parameter(description = "제출 ID", example = "1") Long submissionId,
+            @Parameter(hidden = true) Long adminUserId);
 }

--- a/src/main/java/com/yd/vibecode/global/swagger/AdminSubmissionDetailApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/AdminSubmissionDetailApi.java
@@ -1,0 +1,37 @@
+package com.yd.vibecode.global.swagger;
+
+import com.yd.vibecode.domain.submission.application.dto.response.AdminSubmissionDetailResponse;
+import com.yd.vibecode.global.common.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "관리자 제출 상세", description = "제출 코드·루브릭 등 민감 정보 포함 (ADMIN/MASTER 전용)")
+public interface AdminSubmissionDetailApi extends BaseApi {
+
+    @Operation(
+            summary = "관리자 제출 상세 조회",
+            description = """
+                    제출 ID로 상세 정보를 조회합니다. **ADMIN 또는 MASTER** 권한이 필요합니다.
+
+                    일반 `GET /api/submissions/{id}`와 달리 **제출 소스 코드(`codeInline`)** 및
+                    **채점 루브릭 JSON(`rubricJson`)**을 포함합니다. 쿠키 기반 인증을 사용합니다.
+                    """)
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = AdminSubmissionDetailResponse.class))),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "제출을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    BaseResponse<AdminSubmissionDetailResponse> getAdminSubmissionDetail(
+            @Parameter(description = "제출 ID", example = "1") Long submissionId);
+}

--- a/src/main/java/com/yd/vibecode/global/swagger/SubmissionApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/SubmissionApi.java
@@ -6,6 +6,7 @@ import com.yd.vibecode.domain.submission.application.dto.response.SubmitResponse
 import com.yd.vibecode.global.common.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -43,6 +44,7 @@ public interface SubmissionApi extends BaseApi {
     @Operation(
             summary = "제출 상세 조회",
             description = "제출 ID로 제출 상세 정보를 조회합니다. " +
+                    "본인 제출(`participantId` = 인증 사용자 ID)만 조회할 수 있습니다. " +
                     "채점 완료 시 테스트 케이스 결과, 점수, 메트릭 정보를 포함합니다."
     )
     @ApiResponses(value = {
@@ -52,11 +54,18 @@ public interface SubmissionApi extends BaseApi {
                     content = @Content(schema = @Schema(implementation = SubmissionDetailResponse.class))
             ),
             @ApiResponse(
+                    responseCode = "403",
+                    description = "타인 제출 조회 시도",
+                    content = @Content(schema = @Schema(implementation = BaseResponse.class))
+            ),
+            @ApiResponse(
                     responseCode = "404",
                     description = "제출을 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = BaseResponse.class))
             )
     })
-    BaseResponse<SubmissionDetailResponse> getSubmissionDetail(Long submissionId);
+    BaseResponse<SubmissionDetailResponse> getSubmissionDetail(
+            Long submissionId,
+            @Parameter(hidden = true) Long currentUserId);
 }
 

--- a/src/main/java/com/yd/vibecode/global/swagger/SubmissionStreamApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/SubmissionStreamApi.java
@@ -1,0 +1,31 @@
+package com.yd.vibecode.global.swagger;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "제출 채점 스트림 (응시자)", description = "본인 제출에 대한 채점 SSE (로그인 응시자 전용)")
+public interface SubmissionStreamApi extends BaseApi {
+
+    @Operation(
+            summary = "응시자 채점 결과 SSE",
+            description = """
+                    제출 ID에 대한 채점 진행 상황을 SSE로 수신합니다. **해당 제출의 소유자(토큰의 user id = submissions.participant_id)**만 연결할 수 있습니다.
+
+                    이벤트는 관리자 스트림과 동일하게 `case_result`, `final_score`만 전달되며, 제출 코드·루브릭 등 민감 필드는 포함하지 않습니다.
+                    """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "SSE 스트림 연결 성공", content = @Content()),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content()),
+            @ApiResponse(responseCode = "403", description = "다른 사용자의 제출", content = @Content()),
+            @ApiResponse(responseCode = "404", description = "제출 없음", content = @Content())
+    })
+    SseEmitter streamScoringResultForExaminee(
+            @Parameter(description = "제출 ID", example = "1") Long submissionId,
+            @Parameter(hidden = true) Long currentUserId);
+}

--- a/src/test/java/com/yd/vibecode/domain/admin/application/usecase/GetExamineeBoardUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/application/usecase/GetExamineeBoardUseCaseTest.java
@@ -1,0 +1,135 @@
+package com.yd.vibecode.domain.admin.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.yd.vibecode.domain.admin.application.dto.response.ExamineeBoardResponse;
+import com.yd.vibecode.domain.auth.domain.entity.User;
+import com.yd.vibecode.domain.auth.domain.repository.UserRepository;
+import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
+import com.yd.vibecode.domain.exam.domain.repository.ExamParticipantRepository;
+import com.yd.vibecode.domain.submission.domain.entity.Score;
+import com.yd.vibecode.domain.submission.domain.entity.Submission;
+import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
+import com.yd.vibecode.domain.submission.domain.repository.ScoreRepository;
+import com.yd.vibecode.domain.submission.domain.repository.SubmissionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class GetExamineeBoardUseCaseTest {
+
+    private static final Long EXAM_ID = 1L;
+
+    @Mock
+    private ExamParticipantRepository examParticipantRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SubmissionRepository submissionRepository;
+
+    @Mock
+    private ScoreRepository scoreRepository;
+
+    @InjectMocks
+    private GetExamineeBoardUseCase getExamineeBoardUseCase;
+
+    @Test
+    @DisplayName("participantId(users.id) 일치 시 제출 상태·점수 매핑")
+    void execute_mapsSubmissionByParticipantId() {
+        Long userId = 100L;
+        ExamParticipant ep = ExamParticipant.builder()
+                .examId(EXAM_ID)
+                .participantId(userId)
+                .state("RUNNING")
+                .build();
+        ReflectionTestUtils.setField(ep, "id", 12L);
+
+        User user = User.builder().name("홍길동").phone("010-1234-5678").build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        Submission submission = Submission.builder()
+                .examId(EXAM_ID)
+                .participantId(userId)
+                .specId(10L)
+                .status(SubmissionStatus.DONE)
+                .lang("python")
+                .build();
+        ReflectionTestUtils.setField(submission, "id", 50L);
+
+        Score score = Score.builder()
+                .submissionId(50L)
+                .promptScore(new BigDecimal("40"))
+                .perfScore(new BigDecimal("30"))
+                .correctnessScore(new BigDecimal("30"))
+                .build();
+        score.calculateTotalScore();
+
+        given(examParticipantRepository.findAllByExamId(EXAM_ID)).willReturn(List.of(ep));
+        given(userRepository.findAllById(List.of(userId))).willReturn(List.of(user));
+        given(submissionRepository.findByExamId(EXAM_ID)).willReturn(List.of(submission));
+        given(scoreRepository.findBySubmissionIdIn(List.of(50L))).willReturn(List.of(score));
+
+        List<ExamineeBoardResponse> result = getExamineeBoardUseCase.execute(EXAM_ID);
+
+        assertThat(result).hasSize(1);
+        ExamineeBoardResponse row = result.get(0);
+        assertThat(row.examParticipantId()).isEqualTo(12L);
+        assertThat(row.submitted()).isTrue();
+        assertThat(row.submissionId()).isEqualTo(50L);
+        assertThat(row.submissionStatus()).isEqualTo("DONE");
+        assertThat(row.totalScore()).isEqualByComparingTo(new BigDecimal("100"));
+    }
+
+    @Test
+    @DisplayName("exam_participants.id와 submission.participantId가 우연히 같아도 미제출로 처리")
+    void execute_doesNotFallbackToExamParticipantPk() {
+        Long userId = 100L;
+        Long examParticipantPk = 12L;
+
+        ExamParticipant ep = ExamParticipant.builder()
+                .examId(EXAM_ID)
+                .participantId(userId)
+                .state("RUNNING")
+                .build();
+        ReflectionTestUtils.setField(ep, "id", examParticipantPk);
+
+        User user = User.builder().name("홍길동").phone("010-1234-5678").build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        Submission otherUserSubmission = Submission.builder()
+                .examId(EXAM_ID)
+                .participantId(examParticipantPk)
+                .specId(10L)
+                .status(SubmissionStatus.DONE)
+                .lang("python")
+                .build();
+        ReflectionTestUtils.setField(otherUserSubmission, "id", 99L);
+
+        given(examParticipantRepository.findAllByExamId(EXAM_ID)).willReturn(List.of(ep));
+        given(userRepository.findAllById(List.of(userId))).willReturn(List.of(user));
+        given(submissionRepository.findByExamId(EXAM_ID)).willReturn(List.of(otherUserSubmission));
+        given(scoreRepository.findBySubmissionIdIn(List.of(99L))).willReturn(List.of());
+
+        List<ExamineeBoardResponse> result = getExamineeBoardUseCase.execute(EXAM_ID);
+
+        assertThat(result).hasSize(1);
+        ExamineeBoardResponse row = result.get(0);
+        assertThat(row.submitted()).isFalse();
+        assertThat(row.submissionId()).isNull();
+        assertThat(row.submissionStatus()).isNull();
+        assertThat(row.totalScore()).isNull();
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/admin/application/usecase/GetExamineeBoardUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/application/usecase/GetExamineeBoardUseCaseTest.java
@@ -90,6 +90,9 @@ class GetExamineeBoardUseCaseTest {
         assertThat(row.submitted()).isTrue();
         assertThat(row.submissionId()).isEqualTo(50L);
         assertThat(row.submissionStatus()).isEqualTo("DONE");
+        assertThat(row.promptScore()).isEqualByComparingTo(new BigDecimal("40"));
+        assertThat(row.perfScore()).isEqualByComparingTo(new BigDecimal("30"));
+        assertThat(row.correctnessScore()).isEqualByComparingTo(new BigDecimal("30"));
         assertThat(row.totalScore()).isEqualByComparingTo(new BigDecimal("100"));
     }
 

--- a/src/test/java/com/yd/vibecode/domain/admin/application/usecase/GetSystemStatusUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/application/usecase/GetSystemStatusUseCaseTest.java
@@ -1,0 +1,49 @@
+package com.yd.vibecode.domain.admin.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.yd.vibecode.domain.admin.application.dto.response.SystemStatusResponse;
+
+@ExtendWith(MockitoExtension.class)
+class GetSystemStatusUseCaseTest {
+
+    @Test
+    @DisplayName("DB ping 성공 시 database 서비스 UP")
+    void execute_databaseUp_whenSelect1Succeeds() {
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        given(jdbcTemplate.queryForObject("SELECT 1", Integer.class)).willReturn(1);
+
+        GetSystemStatusUseCase useCase = new GetSystemStatusUseCase(jdbcTemplate, "http://localhost:1");
+
+        SystemStatusResponse response = useCase.execute();
+
+        assertThat(response.services()).hasSize(3);
+        assertThat(response.services().get(0).key()).isEqualTo("api");
+        assertThat(response.services().get(0).status()).isEqualTo("UP");
+        assertThat(response.services().get(1).key()).isEqualTo("database");
+        assertThat(response.services().get(1).status()).isEqualTo("UP");
+        assertThat(response.services().get(1).latencyMs()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("DB ping 실패 시 database 서비스 DOWN")
+    void execute_databaseDown_whenSelect1Fails() {
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        given(jdbcTemplate.queryForObject("SELECT 1", Integer.class))
+            .willThrow(new RuntimeException("connection refused"));
+
+        GetSystemStatusUseCase useCase = new GetSystemStatusUseCase(jdbcTemplate, "http://localhost:1");
+
+        SystemStatusResponse response = useCase.execute();
+
+        assertThat(response.services().get(1).status()).isEqualTo("DOWN");
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/admin/ui/AdminSystemStatusControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/ui/AdminSystemStatusControllerTest.java
@@ -1,0 +1,64 @@
+package com.yd.vibecode.domain.admin.ui;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.yd.vibecode.domain.admin.application.dto.response.SystemStatusResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.SystemStatusResponse.ServiceStatusItem;
+import com.yd.vibecode.domain.admin.application.usecase.GetSystemStatusUseCase;
+import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
+import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
+import com.yd.vibecode.global.security.SecurityConfig;
+import com.yd.vibecode.global.security.TokenProvider;
+
+@WebMvcTest(
+    controllers = AdminSystemStatusController.class,
+    excludeAutoConfiguration = SecurityAutoConfiguration.class,
+    excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+)
+class AdminSystemStatusControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GetSystemStatusUseCase getSystemStatusUseCase;
+
+    @MockBean
+    private JwtBlacklistInterceptor jwtBlacklistInterceptor;
+
+    @MockBean
+    private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @Test
+    @DisplayName("시스템 상태 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void getSystemStatus_success() throws Exception {
+        given(getSystemStatusUseCase.execute())
+            .willReturn(new SystemStatusResponse(List.of(
+                new ServiceStatusItem("api", "API 서버", "UP", 1L),
+                new ServiceStatusItem("database", "데이터베이스", "UP", 8L),
+                new ServiceStatusItem("ai", "AI 게이트웨이", "DOWN", null)
+            )));
+
+        mockMvc.perform(get("/api/admin/system-status"))
+            .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/application/usecase/GetActiveSessionUseCaseTest.java
@@ -299,6 +299,7 @@ class GetActiveSessionUseCaseTest {
         // then
         assertThat(response.examId()).isEqualTo(10L);
         assertThat(response.examParticipantId()).isEqualTo(50L);
+        assertThat(response.participantId()).isEqualTo(20L);
         assertThat(response.specId()).isEqualTo(30L);
         assertThat(response.assignedProblemId()).isEqualTo(40L);
         assertThat(response.examState()).isEqualTo(ExamState.RUNNING);

--- a/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/exam/ui/ExamControllerTest.java
@@ -80,7 +80,7 @@ class ExamControllerTest {
     void getActiveSession_success() throws Exception {
         // given
         ActiveSessionResponse response = new ActiveSessionResponse(
-            1L, 999L, 300L, 200L,
+            1L, 999L, 100L, 300L, 200L,
             ExamState.RUNNING,
             LocalDateTime.of(2026, 5, 6, 9, 0),
             LocalDateTime.of(2026, 5, 6, 11, 0),
@@ -94,6 +94,7 @@ class ExamControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.examId").value(1))
                 .andExpect(jsonPath("$.result.examParticipantId").value(999))
+                .andExpect(jsonPath("$.result.participantId").value(100))
                 .andExpect(jsonPath("$.result.examState").value("RUNNING"));
     }
 
@@ -102,7 +103,7 @@ class ExamControllerTest {
     void getActiveSessionByExam_success() throws Exception {
         // given
         ActiveSessionResponse response = new ActiveSessionResponse(
-            1L, 999L, 300L, 200L,
+            1L, 999L, 100L, 300L, 200L,
             ExamState.RUNNING,
             LocalDateTime.of(2026, 5, 6, 9, 0),
             LocalDateTime.of(2026, 5, 6, 11, 0),
@@ -116,6 +117,7 @@ class ExamControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.examId").value(1))
                 .andExpect(jsonPath("$.result.examParticipantId").value(999))
+                .andExpect(jsonPath("$.result.participantId").value(100))
                 .andExpect(jsonPath("$.result.examState").value("RUNNING"));
     }
 

--- a/src/test/java/com/yd/vibecode/domain/submission/application/usecase/GetAdminSubmissionDetailUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/application/usecase/GetAdminSubmissionDetailUseCaseTest.java
@@ -1,0 +1,140 @@
+package com.yd.vibecode.domain.submission.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.entity.AdminRole;
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.domain.submission.application.dto.response.AdminSubmissionDetailResponse;
+import com.yd.vibecode.domain.submission.application.service.SubmissionDetailAssembler;
+import com.yd.vibecode.domain.submission.domain.entity.Submission;
+import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
+import com.yd.vibecode.domain.submission.domain.repository.ScoreRepository;
+import com.yd.vibecode.domain.submission.domain.repository.SubmissionRunRepository;
+import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+import com.yd.vibecode.global.exception.code.status.SubmissionErrorStatus;
+
+@ExtendWith(MockitoExtension.class)
+class GetAdminSubmissionDetailUseCaseTest {
+
+    @InjectMocks
+    private GetAdminSubmissionDetailUseCase getAdminSubmissionDetailUseCase;
+
+    @Mock
+    private AdminService adminService;
+
+    @Mock
+    private SubmissionService submissionService;
+
+    @Mock
+    private SubmissionRunRepository submissionRunRepository;
+
+    @Mock
+    private ScoreRepository scoreRepository;
+
+    @Mock
+    private SubmissionDetailAssembler submissionDetailAssembler;
+
+    @Test
+    @DisplayName("활성 ADMIN 관리자 — 제출 상세 조회 성공")
+    void execute_success_asAdmin() {
+        Long adminUserId = 1L;
+        Long submissionId = 42L;
+        Admin admin = Admin.builder()
+                .adminNumber("ADM-1")
+                .email("a@test.com")
+                .passwordHash("hash")
+                .role(AdminRole.ADMIN)
+                .isActive(true)
+                .build();
+        Submission submission = Submission.builder()
+                .examId(1L)
+                .participantId(10L)
+                .specId(100L)
+                .status(SubmissionStatus.DONE)
+                .lang("python")
+                .codeInline("print(1)")
+                .build();
+        ReflectionTestUtils.setField(submission, "id", submissionId);
+
+        given(adminService.findById(adminUserId)).willReturn(admin);
+        given(submissionService.findById(submissionId)).willReturn(submission);
+        given(submissionRunRepository.findBySubmissionId(submissionId)).willReturn(Collections.emptyList());
+        given(scoreRepository.findBySubmissionId(submissionId)).willReturn(Optional.empty());
+        given(submissionDetailAssembler.toResponse(submission, Collections.emptyList(), null))
+                .willReturn(new com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse(
+                        submissionId,
+                        SubmissionStatus.DONE,
+                        "python",
+                        new com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse.MetricsInfo(0, 0, 0),
+                        new com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse.TestCaseInfo(0.0, Collections.emptyList()),
+                        new com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse.ScoreInfo(null, null, null, null)));
+
+        AdminSubmissionDetailResponse response =
+                getAdminSubmissionDetailUseCase.execute(adminUserId, submissionId);
+
+        assertThat(response.submissionId()).isEqualTo(submissionId);
+        assertThat(response.codeInline()).isEqualTo("print(1)");
+        verify(submissionService).findById(submissionId);
+    }
+
+    @Test
+    @DisplayName("비활성 관리자 계정 — 403 (AUTH022)")
+    void execute_forbidden_inactiveAdmin() {
+        Long adminUserId = 2L;
+        Admin inactive = Admin.builder()
+                .adminNumber("ADM-2")
+                .email("b@test.com")
+                .passwordHash("hash")
+                .role(AdminRole.ADMIN)
+                .isActive(false)
+                .build();
+        given(adminService.findById(adminUserId)).willReturn(inactive);
+
+        assertThatThrownBy(() -> getAdminSubmissionDetailUseCase.execute(adminUserId, 99L))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> assertThat(((RestApiException) ex).getErrorCode().getCode())
+                        .isEqualTo(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE.getCode().getCode()));
+
+        verify(submissionService, never()).findById(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 submissionId — 404 (SUB001)")
+    void execute_notFound_submission() {
+        Long adminUserId = 1L;
+        Long submissionId = 999L;
+        Admin admin = Admin.builder()
+                .adminNumber("ADM-1")
+                .email("a@test.com")
+                .passwordHash("hash")
+                .role(AdminRole.MASTER)
+                .isActive(true)
+                .build();
+        given(adminService.findById(adminUserId)).willReturn(admin);
+        given(submissionService.findById(submissionId))
+                .willThrow(new RestApiException(SubmissionErrorStatus.SUBMISSION_NOT_FOUND));
+
+        assertThatThrownBy(() -> getAdminSubmissionDetailUseCase.execute(adminUserId, submissionId))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> assertThat(((RestApiException) ex).getErrorCode().getCode())
+                        .isEqualTo(SubmissionErrorStatus.SUBMISSION_NOT_FOUND.getCode().getCode()));
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/submission/application/usecase/GetSubmissionDetailUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/application/usecase/GetSubmissionDetailUseCaseTest.java
@@ -7,6 +7,7 @@ import com.yd.vibecode.domain.submission.domain.entity.Submission;
 import com.yd.vibecode.domain.submission.domain.entity.SubmissionRun;
 import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
 import com.yd.vibecode.domain.submission.domain.entity.Verdict;
+import com.yd.vibecode.domain.submission.application.service.SubmissionDetailAssembler;
 import com.yd.vibecode.domain.submission.domain.repository.ScoreRepository;
 import com.yd.vibecode.domain.submission.domain.repository.SubmissionRunRepository;
 import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
@@ -38,6 +40,9 @@ class GetSubmissionDetailUseCaseTest {
 
     @Mock
     private ScoreRepository scoreRepository;
+
+    @Spy
+    private SubmissionDetailAssembler submissionDetailAssembler = new SubmissionDetailAssembler();
 
     @Test
     @DisplayName("제출 상세 조회 성공: 메트릭 및 점수 계산 확인")

--- a/src/test/java/com/yd/vibecode/domain/submission/application/usecase/GetSubmissionDetailUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/application/usecase/GetSubmissionDetailUseCaseTest.java
@@ -1,16 +1,15 @@
 package com.yd.vibecode.domain.submission.application.usecase;
 
-import com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse;
-import com.yd.vibecode.domain.submission.domain.entity.RunGroup;
-import com.yd.vibecode.domain.submission.domain.entity.Score;
-import com.yd.vibecode.domain.submission.domain.entity.Submission;
-import com.yd.vibecode.domain.submission.domain.entity.SubmissionRun;
-import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
-import com.yd.vibecode.domain.submission.domain.entity.Verdict;
-import com.yd.vibecode.domain.submission.application.service.SubmissionDetailAssembler;
-import com.yd.vibecode.domain.submission.domain.repository.ScoreRepository;
-import com.yd.vibecode.domain.submission.domain.repository.SubmissionRunRepository;
-import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,12 +18,20 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
+import com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse;
+import com.yd.vibecode.domain.submission.application.service.SubmissionDetailAssembler;
+import com.yd.vibecode.domain.submission.domain.entity.RunGroup;
+import com.yd.vibecode.domain.submission.domain.entity.Score;
+import com.yd.vibecode.domain.submission.domain.entity.Submission;
+import com.yd.vibecode.domain.submission.domain.entity.SubmissionRun;
+import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
+import com.yd.vibecode.domain.submission.domain.entity.Verdict;
+import com.yd.vibecode.domain.submission.domain.repository.ScoreRepository;
+import com.yd.vibecode.domain.submission.domain.repository.SubmissionRunRepository;
+import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
+import com.yd.vibecode.global.exception.code.status.SubmissionErrorStatus;
 
 @ExtendWith(MockitoExtension.class)
 class GetSubmissionDetailUseCaseTest {
@@ -45,21 +52,23 @@ class GetSubmissionDetailUseCaseTest {
     private SubmissionDetailAssembler submissionDetailAssembler = new SubmissionDetailAssembler();
 
     @Test
-    @DisplayName("제출 상세 조회 성공: 메트릭 및 점수 계산 확인")
-    void execute_Success() {
-        // given
+    @DisplayName("소유자 일치 — 제출 상세 조회 성공")
+    void execute_success_whenOwner() {
+        Long currentUserId = 100L;
         Long submissionId = 1L;
         Submission submission = Submission.builder()
+                .examId(1L)
+                .participantId(currentUserId)
+                .specId(10L)
                 .status(SubmissionStatus.DONE)
                 .lang("python3.11")
                 .codeLoc(10)
                 .build();
 
         List<SubmissionRun> runs = List.of(
-            SubmissionRun.builder().grp(RunGroup.SAMPLE).verdict(Verdict.AC).timeMs(100).memKb(1024).build(),
-            SubmissionRun.builder().grp(RunGroup.PUBLIC).verdict(Verdict.AC).timeMs(200).memKb(2048).build(),
-            SubmissionRun.builder().grp(RunGroup.PRIVATE).verdict(Verdict.WA).timeMs(150).memKb(1024).build()
-        );
+                SubmissionRun.builder().grp(RunGroup.SAMPLE).verdict(Verdict.AC).timeMs(100).memKb(1024).build(),
+                SubmissionRun.builder().grp(RunGroup.PUBLIC).verdict(Verdict.AC).timeMs(200).memKb(2048).build(),
+                SubmissionRun.builder().grp(RunGroup.PRIVATE).verdict(Verdict.WA).timeMs(150).memKb(1024).build());
 
         Score score = Score.builder()
                 .promptScore(new BigDecimal("30.0"))
@@ -72,21 +81,50 @@ class GetSubmissionDetailUseCaseTest {
         given(submissionRunRepository.findBySubmissionId(submissionId)).willReturn(runs);
         given(scoreRepository.findBySubmissionId(submissionId)).willReturn(Optional.of(score));
 
-        // when
-        SubmissionDetailResponse response = getSubmissionDetailUseCase.execute(submissionId);
+        SubmissionDetailResponse response =
+                getSubmissionDetailUseCase.execute(currentUserId, submissionId);
 
-        // then
         assertThat(response.status()).isEqualTo(SubmissionStatus.DONE);
-        assertThat(response.metrics().timeMsMedian()).isEqualTo(150); // Median of 100, 150, 200 is 150
+        assertThat(response.metrics().timeMsMedian()).isEqualTo(150);
         assertThat(response.metrics().memKbPeak()).isEqualTo(2048);
         assertThat(response.score().total()).isEqualTo(new BigDecimal("60.0"));
-        
-        // Check test case groups
-        // SAMPLE: 1/1 pass
-        // PUBLIC: 1/1 pass
-        // PRIVATE: 0/1 pass
-        // Weights: SAMPLE 0.1, PUBLIC 0.3, PRIVATE 0.6
-        // Weighted Pass Rate: (1.0 * 0.1 + 1.0 * 0.3 + 0.0 * 0.6) / 1.0 = 0.4
         assertThat(response.tc().passRateWeighted()).isEqualTo(0.4);
+    }
+
+    @Test
+    @DisplayName("소유자 불일치 — 403 (COMMON403)")
+    void execute_forbidden_whenNotOwner() {
+        Long currentUserId = 100L;
+        Long submissionId = 1L;
+        Submission submission = Submission.builder()
+                .examId(1L)
+                .participantId(99L)
+                .specId(10L)
+                .status(SubmissionStatus.DONE)
+                .lang("python3.11")
+                .build();
+
+        given(submissionService.findById(submissionId)).willReturn(submission);
+
+        assertThatThrownBy(() -> getSubmissionDetailUseCase.execute(currentUserId, submissionId))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> assertThat(((RestApiException) ex).getErrorCode().getCode())
+                        .isEqualTo(GlobalErrorStatus._FORBIDDEN.getCode().getCode()));
+
+        verify(submissionRunRepository, never()).findBySubmissionId(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 submissionId — 404 (SUB001)")
+    void execute_notFound_submission() {
+        Long currentUserId = 100L;
+        Long submissionId = 999L;
+        given(submissionService.findById(submissionId))
+                .willThrow(new RestApiException(SubmissionErrorStatus.SUBMISSION_NOT_FOUND));
+
+        assertThatThrownBy(() -> getSubmissionDetailUseCase.execute(currentUserId, submissionId))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> assertThat(((RestApiException) ex).getErrorCode().getCode())
+                        .isEqualTo(SubmissionErrorStatus.SUBMISSION_NOT_FOUND.getCode().getCode()));
     }
 }

--- a/src/test/java/com/yd/vibecode/domain/submission/application/usecase/SubmitUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/application/usecase/SubmitUseCaseTest.java
@@ -3,6 +3,9 @@ package com.yd.vibecode.domain.submission.application.usecase;
 import com.yd.vibecode.domain.chat.domain.service.PromptSessionService;
 import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
 import com.yd.vibecode.domain.exam.domain.service.ExamParticipantService;
+import com.yd.vibecode.domain.problem.domain.entity.ProblemSpec;
+import com.yd.vibecode.domain.problem.domain.service.ProblemSpecService;
+import com.yd.vibecode.domain.submission.application.dto.request.AISubmitEvaluationRequest;
 import com.yd.vibecode.domain.submission.application.dto.request.SubmitRequest;
 import com.yd.vibecode.domain.submission.application.dto.response.SubmitResponse;
 import com.yd.vibecode.domain.submission.domain.entity.Submission;
@@ -11,9 +14,11 @@ import com.yd.vibecode.domain.submission.domain.service.OutboxEventService;
 import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
 import com.yd.vibecode.global.exception.RestApiException;
 import com.yd.vibecode.global.exception.code.status.ProblemErrorStatus;
+import com.yd.vibecode.global.exception.code.status.SubmissionErrorStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -21,7 +26,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SubmitUseCaseTest {
@@ -36,6 +43,9 @@ class SubmitUseCaseTest {
     private SubmissionService submissionService;
 
     @Mock
+    private ProblemSpecService problemSpecService;
+
+    @Mock
     private PromptSessionService promptSessionService;
 
     @Mock
@@ -44,7 +54,6 @@ class SubmitUseCaseTest {
     @Test
     @DisplayName("제출 성공")
     void execute_Success() {
-        // given
         Long examId = 1L;
         Long userId = 100L;
         Long specId = 10L;
@@ -54,6 +63,7 @@ class SubmitUseCaseTest {
                 .examId(examId)
                 .participantId(userId)
                 .specId(specId)
+                .assignedProblemId(200L)
                 .build();
 
         Submission submission = Submission.builder()
@@ -63,7 +73,6 @@ class SubmitUseCaseTest {
                 .lang(request.lang())
                 .status(SubmissionStatus.QUEUED)
                 .build();
-        // Set ID via reflection
         try {
             java.lang.reflect.Field idField = submission.getClass().getDeclaredField("id");
             idField.setAccessible(true);
@@ -71,25 +80,19 @@ class SubmitUseCaseTest {
         } catch (Exception e) {
             // Ignore
         }
-        
+
         given(examParticipantService.findByExamIdAndParticipantId(examId, userId)).willReturn(examParticipant);
+        given(submissionService.existsByExamIdAndParticipantId(examId, userId)).willReturn(false);
         given(submissionService.createAndEnqueue(examId, userId, specId, request.lang(), request.code()))
                 .willReturn(submission);
 
-        // when
-        // TransactionSynchronizationManager는 실제 트랜잭션이 없으면 IllegalStateException을 던지므로
-        // 단위 테스트에서는 예외가 발생할 수 있음 (통합 테스트에서 실제 동작 검증)
-        // 실제 프로덕션에서는 @Transactional이 있으므로 문제없음
         SubmitResponse response;
         try {
             response = submitUseCase.execute(examId, userId, request);
         } catch (IllegalStateException | org.springframework.transaction.IllegalTransactionStateException e) {
-            // TransactionSynchronizationManager가 트랜잭션이 없을 때 던지는 예외
-            // 테스트에서는 이 예외를 무시하고 핵심 로직만 검증
             response = new SubmitResponse(123L, SubmissionStatus.QUEUED);
         }
 
-        // then
         assertThat(response.submissionId()).isEqualTo(123L);
         assertThat(response.status()).isEqualTo(SubmissionStatus.QUEUED);
         verify(submissionService).createAndEnqueue(examId, userId, specId, request.lang(), request.code());
@@ -99,7 +102,6 @@ class SubmitUseCaseTest {
     @Test
     @DisplayName("제출 실패: 배정된 스펙이 없는 경우")
     void execute_Fail_NoSpec() {
-        // given
         Long examId = 1L;
         Long userId = 100L;
         SubmitRequest request = new SubmitRequest("python3.11", "print('hello')");
@@ -107,14 +109,90 @@ class SubmitUseCaseTest {
         ExamParticipant examParticipant = ExamParticipant.builder()
                 .examId(examId)
                 .participantId(userId)
-                .specId(null) // No spec assigned
+                .specId(null)
                 .build();
 
         given(examParticipantService.findByExamIdAndParticipantId(examId, userId)).willReturn(examParticipant);
 
-        // when & then
         assertThatThrownBy(() -> submitUseCase.execute(examId, userId, request))
                 .isInstanceOf(RestApiException.class)
                 .extracting("errorCode.code").isEqualTo(ProblemErrorStatus.NO_ASSIGNED_PROBLEM.getCode().getCode());
+    }
+
+    @Test
+    @DisplayName("제출 실패: 이미 제출한 경우 (동일 시험·참가자)")
+    void execute_Fail_AlreadySubmitted() {
+        Long examId = 1L;
+        Long userId = 100L;
+        SubmitRequest request = new SubmitRequest("python", "print(1)");
+        ExamParticipant examParticipant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(userId)
+                .specId(10L)
+                .assignedProblemId(1L)
+                .build();
+
+        given(examParticipantService.findByExamIdAndParticipantId(examId, userId)).willReturn(examParticipant);
+        given(submissionService.existsByExamIdAndParticipantId(examId, userId)).willReturn(true);
+
+        assertThatThrownBy(() -> submitUseCase.execute(examId, userId, request))
+                .isInstanceOf(RestApiException.class)
+                .extracting("errorCode.code").isEqualTo(SubmissionErrorStatus.ALREADY_SUBMITTED.getCode().getCode());
+    }
+
+    @Test
+    @DisplayName("제출 성공: assignedProblemId 없으면 spec에서 problemId 보정")
+    void execute_Success_ProblemIdFromSpec() {
+        Long examId = 1L;
+        Long userId = 100L;
+        Long specId = 10L;
+        SubmitRequest request = new SubmitRequest("python", "x");
+
+        ExamParticipant examParticipant = ExamParticipant.builder()
+                .examId(examId)
+                .participantId(userId)
+                .specId(specId)
+                .assignedProblemId(null)
+                .build();
+
+        ProblemSpec spec = mock(ProblemSpec.class);
+        when(spec.getProblemId()).thenReturn(55L);
+
+        Submission submission = Submission.builder()
+                .examId(examId)
+                .participantId(userId)
+                .specId(specId)
+                .lang(request.lang())
+                .status(SubmissionStatus.QUEUED)
+                .build();
+        try {
+            java.lang.reflect.Field idField = submission.getClass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(submission, 999L);
+        } catch (Exception ignored) {
+        }
+
+        given(examParticipantService.findByExamIdAndParticipantId(examId, userId)).willReturn(examParticipant);
+        given(submissionService.existsByExamIdAndParticipantId(examId, userId)).willReturn(false);
+        given(problemSpecService.findBySpecId(specId)).willReturn(spec);
+        given(submissionService.createAndEnqueue(examId, userId, specId, request.lang(), request.code()))
+                .willReturn(submission);
+
+        try {
+            submitUseCase.execute(examId, userId, request);
+        } catch (IllegalStateException | org.springframework.transaction.IllegalTransactionStateException ignored) {
+        }
+
+        verify(problemSpecService).findBySpecId(specId);
+        verify(outboxEventService).saveEvent(
+                ArgumentMatchers.eq("SUBMISSION"),
+                ArgumentMatchers.eq(999L),
+                ArgumentMatchers.eq("AI_EVAL_REQUEST"),
+                ArgumentMatchers.argThat((Object payload) -> {
+                    if (!(payload instanceof AISubmitEvaluationRequest r)) {
+                        return false;
+                    }
+                    return r.problemId().equals(55L) && r.specId().equals(specId);
+                }));
     }
 }

--- a/src/test/java/com/yd/vibecode/domain/submission/application/usecase/SubmitUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/application/usecase/SubmitUseCaseTest.java
@@ -1,5 +1,22 @@
 package com.yd.vibecode.domain.submission.application.usecase;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.yd.vibecode.domain.chat.domain.service.PromptSessionService;
 import com.yd.vibecode.domain.exam.domain.entity.ExamParticipant;
 import com.yd.vibecode.domain.exam.domain.service.ExamParticipantService;
@@ -15,20 +32,6 @@ import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
 import com.yd.vibecode.global.exception.RestApiException;
 import com.yd.vibecode.global.exception.code.status.ProblemErrorStatus;
 import com.yd.vibecode.global.exception.code.status.SubmissionErrorStatus;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentMatchers;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SubmitUseCaseTest {
@@ -73,30 +76,31 @@ class SubmitUseCaseTest {
                 .lang(request.lang())
                 .status(SubmissionStatus.QUEUED)
                 .build();
-        try {
-            java.lang.reflect.Field idField = submission.getClass().getDeclaredField("id");
-            idField.setAccessible(true);
-            idField.set(submission, 123L);
-        } catch (Exception e) {
-            // Ignore
-        }
+        ReflectionTestUtils.setField(submission, "id", 123L);
 
         given(examParticipantService.findByExamIdAndParticipantId(examId, userId)).willReturn(examParticipant);
         given(submissionService.existsByExamIdAndParticipantId(examId, userId)).willReturn(false);
         given(submissionService.createAndEnqueue(examId, userId, specId, request.lang(), request.code()))
                 .willReturn(submission);
 
-        SubmitResponse response;
-        try {
-            response = submitUseCase.execute(examId, userId, request);
-        } catch (IllegalStateException | org.springframework.transaction.IllegalTransactionStateException e) {
-            response = new SubmitResponse(123L, SubmissionStatus.QUEUED);
-        }
+        SubmitResponse response = submitUseCase.execute(examId, userId, request);
 
         assertThat(response.submissionId()).isEqualTo(123L);
         assertThat(response.status()).isEqualTo(SubmissionStatus.QUEUED);
         verify(submissionService).createAndEnqueue(examId, userId, specId, request.lang(), request.code());
         verify(promptSessionService).getOrCreateSession(examId, userId, specId);
+        verify(outboxEventService).saveEvent(
+                eq("SUBMISSION"),
+                eq(123L),
+                eq("AI_EVAL_REQUEST"),
+                argThat((Object payload) -> {
+                    if (!(payload instanceof AISubmitEvaluationRequest r)) {
+                        return false;
+                    }
+                    return r.problemId().equals(200L)
+                            && r.specId().equals(specId)
+                            && r.submissionId().equals(123L);
+                }));
     }
 
     @Test
@@ -165,12 +169,7 @@ class SubmitUseCaseTest {
                 .lang(request.lang())
                 .status(SubmissionStatus.QUEUED)
                 .build();
-        try {
-            java.lang.reflect.Field idField = submission.getClass().getDeclaredField("id");
-            idField.setAccessible(true);
-            idField.set(submission, 999L);
-        } catch (Exception ignored) {
-        }
+        ReflectionTestUtils.setField(submission, "id", 999L);
 
         given(examParticipantService.findByExamIdAndParticipantId(examId, userId)).willReturn(examParticipant);
         given(submissionService.existsByExamIdAndParticipantId(examId, userId)).willReturn(false);
@@ -178,17 +177,16 @@ class SubmitUseCaseTest {
         given(submissionService.createAndEnqueue(examId, userId, specId, request.lang(), request.code()))
                 .willReturn(submission);
 
-        try {
-            submitUseCase.execute(examId, userId, request);
-        } catch (IllegalStateException | org.springframework.transaction.IllegalTransactionStateException ignored) {
-        }
+        SubmitResponse response = submitUseCase.execute(examId, userId, request);
 
+        assertThat(response.submissionId()).isEqualTo(999L);
+        assertThat(response.status()).isEqualTo(SubmissionStatus.QUEUED);
         verify(problemSpecService).findBySpecId(specId);
         verify(outboxEventService).saveEvent(
-                ArgumentMatchers.eq("SUBMISSION"),
-                ArgumentMatchers.eq(999L),
-                ArgumentMatchers.eq("AI_EVAL_REQUEST"),
-                ArgumentMatchers.argThat((Object payload) -> {
+                eq("SUBMISSION"),
+                eq(999L),
+                eq("AI_EVAL_REQUEST"),
+                argThat((Object payload) -> {
                     if (!(payload instanceof AISubmitEvaluationRequest r)) {
                         return false;
                     }

--- a/src/test/java/com/yd/vibecode/domain/submission/domain/service/SubmissionServiceTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/domain/service/SubmissionServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import static org.mockito.Mockito.verify;
@@ -32,6 +33,32 @@ class SubmissionServiceTest {
 
     @Mock
     private ListOperations<String, String> listOperations;
+
+    @Test
+    @DisplayName("existsByExamIdAndParticipantId — 제출 존재 시 true")
+    void existsByExamIdAndParticipantId_returnsTrue() {
+        Long examId = 1L;
+        Long participantId = 100L;
+        given(submissionRepository.existsByExamIdAndParticipantId(examId, participantId)).willReturn(true);
+
+        assertThat(submissionService.existsByExamIdAndParticipantId(examId, participantId)).isTrue();
+
+        verify(submissionRepository).existsByExamIdAndParticipantId(examId, participantId);
+        verify(submissionRepository, never()).findByExamIdAndParticipantId(examId, participantId);
+    }
+
+    @Test
+    @DisplayName("existsByExamIdAndParticipantId — 제출 없음 시 false")
+    void existsByExamIdAndParticipantId_returnsFalse() {
+        Long examId = 1L;
+        Long participantId = 100L;
+        given(submissionRepository.existsByExamIdAndParticipantId(examId, participantId)).willReturn(false);
+
+        assertThat(submissionService.existsByExamIdAndParticipantId(examId, participantId)).isFalse();
+
+        verify(submissionRepository).existsByExamIdAndParticipantId(examId, participantId);
+        verify(submissionRepository, never()).findByExamIdAndParticipantId(examId, participantId);
+    }
 
     @Test
     @DisplayName("제출 생성 및 Enqueue 성공: 해시 및 LOC 계산 확인")

--- a/src/test/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionDetailControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionDetailControllerTest.java
@@ -80,7 +80,8 @@ class AdminSubmissionDetailControllerTest {
                 new SubmissionDetailResponse.TestCaseInfo(1.0, java.util.List.of()),
                 new SubmissionDetailResponse.ScoreInfo(
                         new BigDecimal("1"), new BigDecimal("2"), new BigDecimal("3"), new BigDecimal("6")),
-                "{\"rubric\":true}");
+                "{\"rubric\":true}",
+                java.util.List.of());
 
         given(getAdminSubmissionDetailUseCase.execute(eq(submissionId))).willReturn(body);
 

--- a/src/test/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionDetailControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionDetailControllerTest.java
@@ -1,0 +1,93 @@
+package com.yd.vibecode.domain.submission.ui;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.yd.vibecode.domain.submission.application.dto.response.AdminSubmissionDetailResponse;
+import com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse;
+import com.yd.vibecode.domain.submission.application.usecase.GetAdminSubmissionDetailUseCase;
+import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
+import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
+import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
+import com.yd.vibecode.global.security.SecurityConfig;
+import com.yd.vibecode.global.security.TokenProvider;
+
+@WebMvcTest(
+        controllers = AdminSubmissionDetailController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+)
+class AdminSubmissionDetailControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GetAdminSubmissionDetailUseCase getAdminSubmissionDetailUseCase;
+
+    @MockBean
+    private JwtBlacklistInterceptor jwtBlacklistInterceptor;
+
+    @MockBean
+    private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @BeforeEach
+    void setUpInterceptor() {
+        // Mock JwtBlacklistInterceptor: Mockito boolean 기본값 false → true (컨트롤러까지 요청 전달)
+        given(jwtBlacklistInterceptor.preHandle(
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class),
+                any())).willReturn(true);
+        given(excludeBlacklistPathProperties.getExcludeAuthPaths()).willReturn(Collections.emptyList());
+    }
+
+    @Test
+    @DisplayName("관리자 제출 상세 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void getAdminSubmissionDetail_success() throws Exception {
+        Long submissionId = 42L;
+        AdminSubmissionDetailResponse body = new AdminSubmissionDetailResponse(
+                submissionId,
+                SubmissionStatus.DONE,
+                "python3.11",
+                "print(1)",
+                new SubmissionDetailResponse.MetricsInfo(10, 512, 1),
+                new SubmissionDetailResponse.TestCaseInfo(1.0, java.util.List.of()),
+                new SubmissionDetailResponse.ScoreInfo(
+                        new BigDecimal("1"), new BigDecimal("2"), new BigDecimal("3"), new BigDecimal("6")),
+                "{\"rubric\":true}");
+
+        given(getAdminSubmissionDetailUseCase.execute(eq(submissionId))).willReturn(body);
+
+        mockMvc.perform(get("/api/admin/submissions/" + submissionId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.submissionId").value(42))
+                .andExpect(jsonPath("$.result.codeInline").value("print(1)"))
+                .andExpect(jsonPath("$.result.rubricJson").value("{\"rubric\":true}"));
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionDetailControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionDetailControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.math.BigDecimal;
 import java.util.Collections;
+import java.util.Optional;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,6 +30,9 @@ import com.yd.vibecode.domain.submission.application.dto.response.AdminSubmissio
 import com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse;
 import com.yd.vibecode.domain.submission.application.usecase.GetAdminSubmissionDetailUseCase;
 import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+import com.yd.vibecode.global.exception.code.status.SubmissionErrorStatus;
 import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
 import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
 import com.yd.vibecode.global.security.SecurityConfig;
@@ -41,54 +45,85 @@ import com.yd.vibecode.global.security.TokenProvider;
 )
 class AdminSubmissionDetailControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+  private static final Long ADMIN_USER_ID = 1L;
 
-    @MockBean
-    private GetAdminSubmissionDetailUseCase getAdminSubmissionDetailUseCase;
+  @Autowired
+  private MockMvc mockMvc;
 
-    @MockBean
-    private JwtBlacklistInterceptor jwtBlacklistInterceptor;
+  @MockBean
+  private GetAdminSubmissionDetailUseCase getAdminSubmissionDetailUseCase;
 
-    @MockBean
-    private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
+  @MockBean
+  private JwtBlacklistInterceptor jwtBlacklistInterceptor;
 
-    @MockBean
-    private TokenProvider tokenProvider;
+  @MockBean
+  private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
 
-    @BeforeEach
-    void setUpInterceptor() {
-        // Mock JwtBlacklistInterceptor: Mockito boolean 기본값 false → true (컨트롤러까지 요청 전달)
-        given(jwtBlacklistInterceptor.preHandle(
-                any(HttpServletRequest.class),
-                any(HttpServletResponse.class),
-                any())).willReturn(true);
-        given(excludeBlacklistPathProperties.getExcludeAuthPaths()).willReturn(Collections.emptyList());
-    }
+  @MockBean
+  private TokenProvider tokenProvider;
 
-    @Test
-    @DisplayName("관리자 제출 상세 조회 성공")
-    @WithMockUser(roles = "ADMIN")
-    void getAdminSubmissionDetail_success() throws Exception {
-        Long submissionId = 42L;
-        AdminSubmissionDetailResponse body = new AdminSubmissionDetailResponse(
-                submissionId,
-                SubmissionStatus.DONE,
-                "python3.11",
-                "print(1)",
-                new SubmissionDetailResponse.MetricsInfo(10, 512, 1),
-                new SubmissionDetailResponse.TestCaseInfo(1.0, java.util.List.of()),
-                new SubmissionDetailResponse.ScoreInfo(
-                        new BigDecimal("1"), new BigDecimal("2"), new BigDecimal("3"), new BigDecimal("6")),
-                "{\"rubric\":true}",
-                java.util.List.of());
+  @BeforeEach
+  void setUp() throws Exception {
+    given(jwtBlacklistInterceptor.preHandle(
+            any(HttpServletRequest.class),
+            any(HttpServletResponse.class),
+            any())).willReturn(true);
+    given(excludeBlacklistPathProperties.getExcludeAuthPaths()).willReturn(Collections.emptyList());
+    given(tokenProvider.getToken(any(HttpServletRequest.class)))
+        .willReturn(Optional.of("mock-token"));
+    given(tokenProvider.isAccessToken("mock-token")).willReturn(true);
+    given(tokenProvider.getId("mock-token")).willReturn(Optional.of(String.valueOf(ADMIN_USER_ID)));
+  }
 
-        given(getAdminSubmissionDetailUseCase.execute(eq(submissionId))).willReturn(body);
+  @Test
+  @DisplayName("관리자 제출 상세 조회 성공")
+  @WithMockUser(roles = "ADMIN")
+  void getAdminSubmissionDetail_success() throws Exception {
+    Long submissionId = 42L;
+    AdminSubmissionDetailResponse body = new AdminSubmissionDetailResponse(
+        submissionId,
+        SubmissionStatus.DONE,
+        "python3.11",
+        "print(1)",
+        new SubmissionDetailResponse.MetricsInfo(10, 512, 1),
+        new SubmissionDetailResponse.TestCaseInfo(1.0, java.util.List.of()),
+        new SubmissionDetailResponse.ScoreInfo(
+            new BigDecimal("1"), new BigDecimal("2"), new BigDecimal("3"), new BigDecimal("6")),
+        "{\"rubric\":true}",
+        java.util.List.of());
 
-        mockMvc.perform(get("/api/admin/submissions/" + submissionId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.submissionId").value(42))
-                .andExpect(jsonPath("$.result.codeInline").value("print(1)"))
-                .andExpect(jsonPath("$.result.rubricJson").value("{\"rubric\":true}"));
-    }
+    given(getAdminSubmissionDetailUseCase.execute(eq(ADMIN_USER_ID), eq(submissionId))).willReturn(body);
+
+    mockMvc.perform(get("/api/admin/submissions/" + submissionId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.submissionId").value(42))
+        .andExpect(jsonPath("$.result.codeInline").value("print(1)"))
+        .andExpect(jsonPath("$.result.rubricJson").value("{\"rubric\":true}"));
+  }
+
+  @Test
+  @DisplayName("관리자 권한 없음(UseCase) — 403")
+  @WithMockUser(roles = "ADMIN")
+  void getAdminSubmissionDetail_forbidden() throws Exception {
+    Long submissionId = 42L;
+    given(getAdminSubmissionDetailUseCase.execute(eq(ADMIN_USER_ID), eq(submissionId)))
+        .willThrow(new RestApiException(AuthErrorStatus.FORBIDDEN));
+
+    mockMvc.perform(get("/api/admin/submissions/" + submissionId))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("AUTH015"));
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 submissionId — 404")
+  @WithMockUser(roles = "ADMIN")
+  void getAdminSubmissionDetail_notFound() throws Exception {
+    Long submissionId = 999L;
+    given(getAdminSubmissionDetailUseCase.execute(eq(ADMIN_USER_ID), eq(submissionId)))
+        .willThrow(new RestApiException(SubmissionErrorStatus.SUBMISSION_NOT_FOUND));
+
+    mockMvc.perform(get("/api/admin/submissions/" + submissionId))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("SUB001"));
+  }
 }

--- a/src/test/java/com/yd/vibecode/domain/submission/ui/ExamineeSubmissionStreamControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/ui/ExamineeSubmissionStreamControllerTest.java
@@ -1,0 +1,103 @@
+package com.yd.vibecode.domain.submission.ui;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.yd.vibecode.domain.submission.domain.entity.Submission;
+import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
+import com.yd.vibecode.domain.submission.infrastructure.SseEmitterRegistry;
+import com.yd.vibecode.global.config.WebMvcConfig;
+import com.yd.vibecode.global.exception.ExceptionAdvice;
+import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
+import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
+import com.yd.vibecode.global.security.SecurityConfig;
+import com.yd.vibecode.global.security.TokenProvider;
+
+@WebMvcTest(
+        controllers = ExamineeSubmissionStreamController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+)
+@Import({WebMvcConfig.class, ExceptionAdvice.class})
+class ExamineeSubmissionStreamControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SubmissionService submissionService;
+
+    @MockBean
+    private SseEmitterRegistry sseEmitterRegistry;
+
+    @MockBean
+    private JwtBlacklistInterceptor jwtBlacklistInterceptor;
+
+    @MockBean
+    private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        given(jwtBlacklistInterceptor.preHandle(
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class),
+                any())).willReturn(true);
+        given(excludeBlacklistPathProperties.getExcludeAuthPaths()).willReturn(Collections.emptyList());
+        given(tokenProvider.getToken(any(HttpServletRequest.class))).willReturn(Optional.of("access-token"));
+        given(tokenProvider.isAccessToken("access-token")).willReturn(true);
+    }
+
+    @Test
+    @DisplayName("소유자 불일치 시 403")
+    void stream_forbiddenWhenNotOwner() throws Exception {
+        given(tokenProvider.getId("access-token")).willReturn(Optional.of("100"));
+        Submission submission = mock(Submission.class);
+        given(submission.getParticipantId()).willReturn(99L);
+        given(submissionService.findById(1L)).willReturn(submission);
+
+        mockMvc.perform(get("/api/submissions/1/stream"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("소유자 일치 시 200 및 register 호출")
+    void stream_okWhenOwner() throws Exception {
+        given(tokenProvider.getId("access-token")).willReturn(Optional.of("100"));
+        Submission submission = mock(Submission.class);
+        given(submission.getParticipantId()).willReturn(100L);
+        given(submissionService.findById(1L)).willReturn(submission);
+        given(sseEmitterRegistry.register(eq(1L)))
+                .willAnswer(inv -> new org.springframework.web.servlet.mvc.method.annotation.SseEmitter(60_000L));
+
+        mockMvc.perform(get("/api/submissions/1/stream"))
+                .andExpect(status().isOk());
+
+        verify(sseEmitterRegistry).register(1L);
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/submission/ui/SubmissionControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/ui/SubmissionControllerTest.java
@@ -1,0 +1,129 @@
+package com.yd.vibecode.domain.submission.ui;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.yd.vibecode.domain.submission.application.dto.response.SubmissionDetailResponse;
+import com.yd.vibecode.domain.submission.application.usecase.GetSubmissionDetailUseCase;
+import com.yd.vibecode.domain.submission.application.usecase.SubmitUseCase;
+import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
+import com.yd.vibecode.global.config.WebMvcConfig;
+import com.yd.vibecode.global.exception.ExceptionAdvice;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
+import com.yd.vibecode.global.exception.code.status.SubmissionErrorStatus;
+import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
+import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
+import com.yd.vibecode.global.security.SecurityConfig;
+import com.yd.vibecode.global.security.TokenProvider;
+
+@WebMvcTest(
+        controllers = SubmissionController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+)
+@Import({WebMvcConfig.class, ExceptionAdvice.class})
+class SubmissionControllerTest {
+
+    private static final Long CURRENT_USER_ID = 100L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SubmitUseCase submitUseCase;
+
+    @MockBean
+    private GetSubmissionDetailUseCase getSubmissionDetailUseCase;
+
+    @MockBean
+    private JwtBlacklistInterceptor jwtBlacklistInterceptor;
+
+    @MockBean
+    private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        given(jwtBlacklistInterceptor.preHandle(
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class),
+                any())).willReturn(true);
+        given(excludeBlacklistPathProperties.getExcludeAuthPaths()).willReturn(Collections.emptyList());
+        given(tokenProvider.getToken(any(HttpServletRequest.class)))
+                .willReturn(Optional.of("access-token"));
+        given(tokenProvider.isAccessToken("access-token")).willReturn(true);
+        given(tokenProvider.getId("access-token"))
+                .willReturn(Optional.of(String.valueOf(CURRENT_USER_ID)));
+    }
+
+    @Test
+    @DisplayName("본인 제출 상세 조회 성공 — 200")
+    void getSubmissionDetail_success() throws Exception {
+        Long submissionId = 1L;
+        SubmissionDetailResponse body = new SubmissionDetailResponse(
+                submissionId,
+                SubmissionStatus.DONE,
+                "python3.11",
+                new SubmissionDetailResponse.MetricsInfo(150, 2048, 10),
+                new SubmissionDetailResponse.TestCaseInfo(0.4, List.of()),
+                new SubmissionDetailResponse.ScoreInfo(
+                        new BigDecimal("30"), new BigDecimal("20"), new BigDecimal("10"), new BigDecimal("60")));
+
+        given(getSubmissionDetailUseCase.execute(eq(CURRENT_USER_ID), eq(submissionId))).willReturn(body);
+
+        mockMvc.perform(get("/api/submissions/" + submissionId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.status").value("DONE"));
+    }
+
+    @Test
+    @DisplayName("타인 제출 조회 — 403")
+    void getSubmissionDetail_forbidden() throws Exception {
+        Long submissionId = 1L;
+        given(getSubmissionDetailUseCase.execute(eq(CURRENT_USER_ID), eq(submissionId)))
+                .willThrow(new RestApiException(GlobalErrorStatus._FORBIDDEN));
+
+        mockMvc.perform(get("/api/submissions/" + submissionId))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 submissionId — 404")
+    void getSubmissionDetail_notFound() throws Exception {
+        Long submissionId = 999L;
+        given(getSubmissionDetailUseCase.execute(eq(CURRENT_USER_ID), eq(submissionId)))
+                .willThrow(new RestApiException(SubmissionErrorStatus.SUBMISSION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/submissions/" + submissionId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("SUB001"));
+    }
+}

--- a/src/test/java/com/yd/vibecode/global/exception/ExceptionAdviceTest.java
+++ b/src/test/java/com/yd/vibecode/global/exception/ExceptionAdviceTest.java
@@ -1,0 +1,114 @@
+package com.yd.vibecode.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+
+import com.yd.vibecode.global.common.BaseResponse;
+import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
+import com.yd.vibecode.global.exception.code.status.SubmissionErrorStatus;
+
+class ExceptionAdviceTest {
+
+    private final ExceptionAdvice exceptionAdvice = new ExceptionAdvice();
+
+    @Test
+    @DisplayName("(exam_id, participant_id) 유니크 위반 → ALREADY_SUBMITTED (SUB002)")
+    void handleDataIntegrityViolation_duplicateExamParticipant_returnsAlreadySubmitted() {
+        String pgMessage = """
+                ERROR: duplicate key value violates unique constraint "submissions_exam_id_participant_id_key"
+                Detail: Key (exam_id, participant_id)=(1, 10) already exists.
+                """;
+        DataIntegrityViolationException ex = new DataIntegrityViolationException(
+                "could not execute statement",
+                new RuntimeException(pgMessage));
+
+        ResponseEntity<BaseResponse<String>> response =
+                exceptionAdvice.handleDataIntegrityViolation(ex);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(400);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode())
+                .isEqualTo(SubmissionErrorStatus.ALREADY_SUBMITTED.getCode().getCode());
+    }
+
+    @Test
+    @DisplayName("Hibernate constraintName에 exam_id·participant_id 포함 시 → ALREADY_SUBMITTED")
+    void handleDataIntegrityViolation_hibernateConstraintName_returnsAlreadySubmitted() {
+        SQLException sqlEx = new SQLException("Duplicate entry '1-10' for key 'submissions_exam_id_participant_id_key'");
+        ConstraintViolationException hibernateEx = new ConstraintViolationException(
+                "could not execute statement",
+                sqlEx,
+                "submissions_exam_id_participant_id_key");
+        DataIntegrityViolationException ex = new DataIntegrityViolationException(
+                "could not execute statement", hibernateEx);
+
+        ResponseEntity<BaseResponse<String>> response =
+                exceptionAdvice.handleDataIntegrityViolation(ex);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode())
+                .isEqualTo(SubmissionErrorStatus.ALREADY_SUBMITTED.getCode().getCode());
+    }
+
+    @Test
+    @DisplayName("submissions FK 위반 — ALREADY_SUBMITTED가 아닌 _EXIST_ENTITY")
+    void handleDataIntegrityViolation_submissionsFk_returnsExistEntity() {
+        String fkMessage = """
+                ERROR: insert or update on table "submissions" violates foreign key constraint "fk_submissions_exam"
+                Detail: Key (exam_id)=(999) is not present in table "exams".
+                """;
+        DataIntegrityViolationException ex = new DataIntegrityViolationException(
+                "could not execute statement",
+                new RuntimeException(fkMessage));
+
+        ResponseEntity<BaseResponse<String>> response =
+                exceptionAdvice.handleDataIntegrityViolation(ex);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode())
+                .isEqualTo(GlobalErrorStatus._EXIST_ENTITY.getCode().getCode());
+    }
+
+    @Test
+    @DisplayName("submissions NOT NULL 위반 — ALREADY_SUBMITTED가 아닌 _EXIST_ENTITY")
+    void handleDataIntegrityViolation_submissionsNotNull_returnsExistEntity() {
+        String notNullMessage = """
+                ERROR: null value in column "lang" of relation "submissions" violates not-null constraint
+                """;
+        DataIntegrityViolationException ex = new DataIntegrityViolationException(
+                "could not execute statement",
+                new RuntimeException(notNullMessage));
+
+        ResponseEntity<BaseResponse<String>> response =
+                exceptionAdvice.handleDataIntegrityViolation(ex);
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode())
+                .isEqualTo(GlobalErrorStatus._EXIST_ENTITY.getCode().getCode());
+    }
+
+    @Test
+    @DisplayName("submissions 테이블명만 포함 — ALREADY_SUBMITTED가 아님")
+    void isDuplicateSubmissionConstraintViolation_submissionsTableOnly_returnsFalse() {
+        DataIntegrityViolationException ex = new DataIntegrityViolationException(
+                "insert into submissions (exam_id, lang) values (1, 'python') failed");
+
+        assertThat(ExceptionAdvice.isDuplicateSubmissionConstraintViolation(ex)).isFalse();
+    }
+
+    @Test
+    @DisplayName("duplicate+submission 키워드만 있고 exam_id·participant_id 없음 — false")
+    void isDuplicateSubmissionConstraintViolation_duplicateSubmissionWithoutColumns_returnsFalse() {
+        DataIntegrityViolationException ex = new DataIntegrityViolationException(
+                "duplicate submission record detected");
+
+        assertThat(ExceptionAdvice.isDuplicateSubmissionConstraintViolation(ex)).isFalse();
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 관리자 보드 API 응답에 채점 점수 필드 추가
  - promptScore
  - perfScore
  - correctnessScore
- 관리자 통계/분석 화면에서 사용할 수 있도록 제출자 점수 데이터 확장
- 관리자 서버 상태 조회 API 추가
  - `GET /api/admin/system-status`
  - API 서버, 데이터베이스, AI 게이트웨이 상태 확인
  - DB `SELECT 1` 기반 연결 확인
  - AI 서버 `/health` 기반 연결 확인
- 서버 상태 API 관련 UseCase / Controller / Response DTO 추가
- 관련 단위 테스트 추가

## 확인 사항

- `GetExamineeBoardUseCaseTest` 통과
- `GetSystemStatusUseCaseTest` 통과
- `AdminSystemStatusControllerTest` 통과
- DB schema 변경 없음

## 참고

- AI 게이트웨이는 `ai.server.url` 기준으로 `/health`를 호출합니다.
- AI 서버가 꺼져 있으면 해당 항목은 점검 필요 상태로 표시됩니다.