### PR TITLE
Feature/master UI layout refactor

### DIFF
--- a/scripts/migration/add_admins_display_name.sql
+++ b/scripts/migration/add_admins_display_name.sql
@@ -1,0 +1,3 @@
+-- admins.display_name: 관리자 표시 이름 (Hibernate ddl-auto=update 미사용 환경용)
+ALTER TABLE admins
+    ADD COLUMN IF NOT EXISTS display_name VARCHAR(100) NULL;

--- a/scripts/migration/add_admins_last_login_at.sql
+++ b/scripts/migration/add_admins_last_login_at.sql
@@ -1,3 +1,3 @@
 -- admins.last_login_at: 관리자 로그인 성공 시각 (Hibernate ddl-auto=update 미사용 환경용)
 ALTER TABLE admins
-    ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMPTZ NULL;
+    ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMP NULL;

--- a/scripts/migration/add_admins_last_login_at.sql
+++ b/scripts/migration/add_admins_last_login_at.sql
@@ -1,0 +1,3 @@
+-- admins.last_login_at: 관리자 로그인 성공 시각 (Hibernate ddl-auto=update 미사용 환경용)
+ALTER TABLE admins
+    ADD COLUMN IF NOT EXISTS last_login_at TIMESTAMPTZ NULL;

--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/AdminListResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/AdminListResponse.java
@@ -25,7 +25,7 @@ public record AdminListResponse(
             return new AdminInfo(
                 admin.getId(),
                 admin.getAdminNumber(),
-                admin.resolveDisplayName(),
+                admin.getDisplayName(),
                 admin.getEmail(),
                 admin.getRole(),
                 admin.getIs2faEnabled(),

--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/AdminListResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/AdminListResponse.java
@@ -1,5 +1,6 @@
 package com.yd.vibecode.domain.admin.application.dto.response;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.yd.vibecode.domain.auth.domain.entity.Admin;
@@ -11,25 +12,32 @@ public record AdminListResponse(
     public record AdminInfo(
         Long id,
         String adminNumber,
+        String displayName,
         String email,
         AdminRole role,
-        Boolean is2faEnabled
+        Boolean is2faEnabled,
+        Boolean isActive,
+        LocalDateTime createdAt,
+        LocalDateTime adminNumberIssuedAt,
+        LocalDateTime lastLoginAt
     ) {
-        public static AdminInfo from(Admin admin) {
+        public static AdminInfo from(Admin admin, LocalDateTime adminNumberIssuedAt) {
             return new AdminInfo(
                 admin.getId(),
                 admin.getAdminNumber(),
+                admin.resolveDisplayName(),
                 admin.getEmail(),
                 admin.getRole(),
-                admin.getIs2faEnabled()
+                admin.getIs2faEnabled(),
+                admin.getIsActive(),
+                admin.getCreatedAt(),
+                adminNumberIssuedAt,
+                admin.getLastLoginAt()
             );
         }
     }
 
-    public static AdminListResponse from(List<Admin> admins) {
-        List<AdminInfo> adminInfos = admins.stream()
-            .map(AdminInfo::from)
-            .toList();
+    public static AdminListResponse of(List<AdminInfo> adminInfos) {
         return new AdminListResponse(adminInfos);
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/ProblemDetailResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/ProblemDetailResponse.java
@@ -1,0 +1,76 @@
+package com.yd.vibecode.domain.admin.application.dto.response;
+
+import com.yd.vibecode.domain.problem.domain.entity.Difficulty;
+import com.yd.vibecode.domain.problem.domain.entity.ProblemStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "관리자/마스터 문제 상세 (공개 스펙만, 테스트케이스 미포함)")
+public record ProblemDetailResponse(
+    @Schema(description = "문제 ID", example = "1")
+    Long id,
+
+    @Schema(description = "문제 제목", example = "외판원 순회")
+    String title,
+
+    @Schema(description = "난이도", example = "MEDIUM")
+    Difficulty difficulty,
+
+    @Schema(description = "태그 목록", example = "[\"dp\", \"graph\"]")
+    List<String> tags,
+
+    @Schema(description = "스펙 버전", example = "1")
+    Integer version,
+
+    @Schema(description = "문제 본문 (Markdown)")
+    String contentMd,
+
+    @Schema(description = "실행 제한")
+    LimitsInfo limits,
+
+    @Schema(description = "언어/API 제한")
+    RestrictionsInfo restrictions,
+
+    @Schema(description = "채점기 유형")
+    CheckerInfo checker,
+
+    @Schema(description = "문제 생성일시")
+    LocalDateTime createdAt,
+
+    @Schema(description = "문제 수정일시")
+    LocalDateTime updatedAt,
+
+    @Schema(description = "스펙 게시일시")
+    LocalDateTime publishedAt,
+
+    @Schema(description = "문제 상태", example = "PUBLISHED")
+    ProblemStatus status,
+
+    @Schema(description = "사용 가능 여부 (PUBLISHED)")
+    boolean usable
+) {
+    public record LimitsInfo(
+        @Schema(description = "시간 제한(ms)", example = "2000")
+        Integer timeMs,
+
+        @Schema(description = "메모리 제한(MB)", example = "256")
+        Integer memoryMb
+    ) {
+    }
+
+    public record RestrictionsInfo(
+        @Schema(description = "허용 언어")
+        List<String> allowedLangs,
+
+        @Schema(description = "금지 API")
+        List<String> forbiddenApis
+    ) {
+    }
+
+    public record CheckerInfo(
+        @Schema(description = "채점기 타입", example = "equality")
+        String type
+    ) {
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/ResetAdminPasswordByMasterResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/dto/response/ResetAdminPasswordByMasterResponse.java
@@ -1,0 +1,6 @@
+package com.yd.vibecode.domain.admin.application.dto.response;
+
+public record ResetAdminPasswordByMasterResponse(
+    String temporaryPassword
+) {
+}

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetAllAdminsUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetAllAdminsUseCase.java
@@ -1,6 +1,9 @@
 package com.yd.vibecode.domain.admin.application.usecase;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,13 +37,23 @@ public class GetAllAdminsUseCase {
                 .filter(admin -> !admin.isDeleted())
                 .toList();
 
+        List<String> adminNumbers = admins.stream()
+                .map(Admin::getAdminNumber)
+                .toList();
+
+        Map<String, LocalDateTime> issuedAtByAdminNumber = adminNumbers.isEmpty()
+                ? Map.of()
+                : adminNumberRepository.findByAdminNumberIn(adminNumbers).stream()
+                        .collect(Collectors.toMap(
+                                AdminNumber::getAdminNumber,
+                                AdminNumber::getCreatedAt
+                        ));
+
         List<AdminListResponse.AdminInfo> adminInfos = admins.stream()
-                .map(admin -> {
-                    var issuedAt = adminNumberRepository.findByAdminNumber(admin.getAdminNumber())
-                            .map(AdminNumber::getCreatedAt)
-                            .orElse(null);
-                    return AdminListResponse.AdminInfo.from(admin, issuedAt);
-                })
+                .map(admin -> AdminListResponse.AdminInfo.from(
+                        admin,
+                        issuedAtByAdminNumber.get(admin.getAdminNumber())
+                ))
                 .toList();
 
         return AdminListResponse.of(adminInfos);

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetAllAdminsUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetAllAdminsUseCase.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.yd.vibecode.domain.admin.application.dto.response.AdminListResponse;
 import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.entity.AdminNumber;
+import com.yd.vibecode.domain.auth.domain.repository.AdminNumberRepository;
 import com.yd.vibecode.domain.auth.domain.service.AdminService;
 import com.yd.vibecode.global.exception.RestApiException;
 import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class GetAllAdminsUseCase {
 
     private final AdminService adminService;
+    private final AdminNumberRepository adminNumberRepository;
 
     @Transactional(readOnly = true)
     public AdminListResponse execute(Long requesterId) {
@@ -27,9 +30,20 @@ public class GetAllAdminsUseCase {
             throw new RestApiException(AuthErrorStatus.MASTER_ONLY);
         }
 
-        // 모든 관리자 조회
-        List<Admin> admins = adminService.findAll();
-        return AdminListResponse.from(admins);
+        List<Admin> admins = adminService.findAll().stream()
+                .filter(admin -> !admin.isDeleted())
+                .toList();
+
+        List<AdminListResponse.AdminInfo> adminInfos = admins.stream()
+                .map(admin -> {
+                    var issuedAt = adminNumberRepository.findByAdminNumber(admin.getAdminNumber())
+                            .map(AdminNumber::getCreatedAt)
+                            .orElse(null);
+                    return AdminListResponse.AdminInfo.from(admin, issuedAt);
+                })
+                .toList();
+
+        return AdminListResponse.of(adminInfos);
     }
 }
 

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamsUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetExamsUseCase.java
@@ -2,11 +2,15 @@ package com.yd.vibecode.domain.admin.application.usecase;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.repository.AdminRepository;
 import com.yd.vibecode.domain.exam.application.dto.response.ExamResponse;
 import com.yd.vibecode.domain.exam.domain.entity.Exam;
 import com.yd.vibecode.domain.exam.domain.repository.ExamParticipantRepository;
@@ -23,6 +27,7 @@ public class GetExamsUseCase {
     private final ExamRepository examRepository;
     private final ExamParticipantRepository examParticipantRepository;
     private final SubmissionRepository submissionRepository;
+    private final AdminRepository adminRepository;
 
     public List<ExamResponse> execute() {
         List<Exam> exams = examRepository.findAll();
@@ -41,12 +46,30 @@ public class GetExamsUseCase {
                 .stream()
                 .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
 
+        Set<Long> creatorAdminIds = exams.stream()
+                .map(Exam::getCreatedBy)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> creatorNameByAdminId = creatorAdminIds.isEmpty()
+                ? Map.of()
+                : adminRepository.findByIdIn(creatorAdminIds).stream()
+                        .collect(Collectors.toMap(Admin::getId, Admin::resolveDisplayName));
+
         return exams.stream()
                 .map(exam -> ExamResponse.from(
                         exam,
                         participantCounts.getOrDefault(exam.getId(), 0L),
-                        completedCounts.getOrDefault(exam.getId(), 0L)
+                        completedCounts.getOrDefault(exam.getId(), 0L),
+                        resolveCreatorName(creatorNameByAdminId, exam.getCreatedBy())
                 ))
                 .collect(Collectors.toList());
+    }
+
+    private static String resolveCreatorName(Map<Long, String> creatorNameByAdminId, Long createdBy) {
+        if (createdBy == null) {
+            return null;
+        }
+        return creatorNameByAdminId.get(createdBy);
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetProblemDetailUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/GetProblemDetailUseCase.java
@@ -1,0 +1,105 @@
+package com.yd.vibecode.domain.admin.application.usecase;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yd.vibecode.domain.admin.application.dto.response.ProblemDetailResponse;
+import com.yd.vibecode.domain.problem.domain.entity.Problem;
+import com.yd.vibecode.domain.problem.domain.entity.ProblemSpec;
+import com.yd.vibecode.domain.problem.domain.entity.ProblemStatus;
+import com.yd.vibecode.domain.problem.domain.repository.ProblemSpecRepository;
+import com.yd.vibecode.domain.problem.domain.service.ProblemService;
+import com.yd.vibecode.domain.problem.domain.service.ProblemSpecService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.ProblemErrorStatus;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 관리자/마스터 — problemId 기준 문제 상세(공개 스펙) 조회
+ */
+@Service
+@RequiredArgsConstructor
+public class GetProblemDetailUseCase {
+
+    private final ProblemService problemService;
+    private final ProblemSpecService problemSpecService;
+    private final ProblemSpecRepository problemSpecRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(readOnly = true)
+    public ProblemDetailResponse execute(Long problemId) {
+        Problem problem = problemService.findById(problemId);
+        ProblemSpec spec = resolveCurrentSpec(problem);
+        return buildResponse(problem, spec);
+    }
+
+    private ProblemSpec resolveCurrentSpec(Problem problem) {
+        if (problem.getCurrentSpecId() != null) {
+            return problemSpecService.findBySpecId(problem.getCurrentSpecId());
+        }
+        return problemSpecRepository.findByProblemIdOrderByVersionDesc(problem.getId()).stream()
+            .findFirst()
+            .orElseThrow(() -> new RestApiException(ProblemErrorStatus.SPEC_NOT_FOUND));
+    }
+
+    private ProblemDetailResponse buildResponse(Problem problem, ProblemSpec spec) {
+        try {
+            List<String> tags = objectMapper.readValue(
+                problem.getTags() != null ? problem.getTags() : "[]",
+                new TypeReference<List<String>>() {}
+            );
+
+            Map<String, Object> checkerMap = objectMapper.readValue(
+                spec.getCheckerJson() != null ? spec.getCheckerJson() : "{}",
+                new TypeReference<Map<String, Object>>() {}
+            );
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> limitsMap = (Map<String, Object>) checkerMap.getOrDefault("limits", Map.of());
+            int timeMs = limitsMap.containsKey("timeMs")
+                ? ((Number) limitsMap.get("timeMs")).intValue()
+                : 2000;
+            int memoryMb = limitsMap.containsKey("memoryMb")
+                ? ((Number) limitsMap.get("memoryMb")).intValue()
+                : 512;
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> restrictionsMap = (Map<String, Object>) checkerMap.getOrDefault("restrictions", Map.of());
+            @SuppressWarnings("unchecked")
+            List<String> allowedLangs = (List<String>) restrictionsMap.getOrDefault(
+                "allowedLangs",
+                List.of("cpp17", "python3.11")
+            );
+            @SuppressWarnings("unchecked")
+            List<String> forbiddenApis = (List<String>) restrictionsMap.getOrDefault("forbiddenApis", List.of());
+
+            String checkerType = checkerMap.getOrDefault("type", "equality").toString();
+            ProblemStatus status = problem.getStatus();
+            boolean usable = status == ProblemStatus.PUBLISHED;
+
+            return new ProblemDetailResponse(
+                problem.getId(),
+                problem.getTitle(),
+                problem.getDifficulty(),
+                tags,
+                spec.getVersion(),
+                spec.getContentMd() != null ? spec.getContentMd() : "",
+                new ProblemDetailResponse.LimitsInfo(timeMs, memoryMb),
+                new ProblemDetailResponse.RestrictionsInfo(allowedLangs, forbiddenApis),
+                new ProblemDetailResponse.CheckerInfo(checkerType),
+                problem.getCreatedAt(),
+                problem.getUpdatedAt(),
+                spec.getPublishedAt(),
+                status,
+                usable
+            );
+        } catch (RestApiException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build problem detail response", e);
+        }
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/ResetAdminPasswordByMasterUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/ResetAdminPasswordByMasterUseCase.java
@@ -1,0 +1,46 @@
+package com.yd.vibecode.domain.admin.application.usecase;
+
+import com.yd.vibecode.domain.admin.application.dto.response.ResetAdminPasswordByMasterResponse;
+import com.yd.vibecode.domain.admin.domain.service.AdminAuditLogService;
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+import com.yd.vibecode.global.util.TemporaryPasswordGenerator;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ResetAdminPasswordByMasterUseCase {
+
+    private final AdminService adminService;
+    private final AdminAuditLogService adminAuditLogService;
+    private final TemporaryPasswordGenerator temporaryPasswordGenerator;
+
+    @Transactional
+    public ResetAdminPasswordByMasterResponse execute(Long requesterId, String adminNumber) {
+        Admin requester = adminService.findById(requesterId);
+        if (!requester.isMaster()) {
+            throw new RestApiException(AuthErrorStatus.MASTER_ONLY);
+        }
+
+        Admin target = adminService.findByAdminNumber(adminNumber);
+        if (target.isMaster()) {
+            throw new RestApiException(AuthErrorStatus.MASTER_ACCOUNT_PASSWORD_CANNOT_BE_RESET);
+        }
+
+        String temporaryPassword = temporaryPasswordGenerator.generate();
+        String newPasswordHash = adminService.encodePassword(temporaryPassword);
+        target.updatePassword(newPasswordHash);
+
+        adminAuditLogService.log(requesterId, "RESET_PASSWORD_BY_MASTER", Map.of(
+            "targetAdminId", target.getId(),
+            "targetAdminNumber", target.getAdminNumber()
+        ));
+
+        return new ResetAdminPasswordByMasterResponse(temporaryPassword);
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/admin/ui/AdminNumberController.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/ui/AdminNumberController.java
@@ -1,59 +1,71 @@
-package com.yd.vibecode.domain.admin.ui;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.yd.vibecode.domain.admin.application.dto.request.AdminNumberIssueRequest;
-import com.yd.vibecode.domain.admin.application.dto.request.AdminNumberUpdateRequest;
-import com.yd.vibecode.domain.admin.application.dto.response.AdminListResponse;
-import com.yd.vibecode.domain.admin.application.dto.response.AdminNumberResponse;
-import com.yd.vibecode.domain.admin.application.usecase.GetAllAdminsUseCase;
-import com.yd.vibecode.domain.admin.application.usecase.IssueAdminNumberUseCase;
-import com.yd.vibecode.domain.admin.application.usecase.UpdateAdminNumberUseCase;
-import com.yd.vibecode.global.annotation.CurrentUser;
-import com.yd.vibecode.global.common.BaseResponse;
-import com.yd.vibecode.global.swagger.AdminNumberApi;
-
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-
-@RestController
-@RequiredArgsConstructor
-@RequestMapping("/api/admin/admin-numbers")
-public class AdminNumberController implements AdminNumberApi {
-
-    private final IssueAdminNumberUseCase issueAdminNumberUseCase;
-    private final UpdateAdminNumberUseCase updateAdminNumberUseCase;
-    private final GetAllAdminsUseCase getAllAdminsUseCase;
-
-    @GetMapping("/admins")
-    @Override
-    public BaseResponse<AdminListResponse> getAllAdmins(@CurrentUser String adminId) {
-        AdminListResponse response = getAllAdminsUseCase.execute(Long.parseLong(adminId));
-        return BaseResponse.onSuccess(response);
-    }
-
-    @PostMapping
-    @Override
-    public BaseResponse<AdminNumberResponse> issueAdminNumber(@CurrentUser String adminId,
-                                                              @Valid @RequestBody AdminNumberIssueRequest request) {
-        AdminNumberResponse response = issueAdminNumberUseCase.execute(Long.parseLong(adminId), request);
-        return BaseResponse.onSuccess(response);
-    }
-
-    @PatchMapping("/{adminNumber}")
-    @Override
-    public BaseResponse<AdminNumberResponse> updateAdminNumber(@CurrentUser String adminId,
-                                                               @PathVariable String adminNumber,
-                                                               @Valid @RequestBody AdminNumberUpdateRequest request) {
-        AdminNumberResponse response = updateAdminNumberUseCase.execute(Long.parseLong(adminId), adminNumber, request);
-        return BaseResponse.onSuccess(response);
-    }
-}
-
-
+package com.yd.vibecode.domain.admin.ui;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.yd.vibecode.domain.admin.application.dto.request.AdminNumberIssueRequest;
+import com.yd.vibecode.domain.admin.application.dto.request.AdminNumberUpdateRequest;
+import com.yd.vibecode.domain.admin.application.dto.response.AdminListResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.AdminNumberResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.ResetAdminPasswordByMasterResponse;
+import com.yd.vibecode.domain.admin.application.usecase.GetAllAdminsUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.IssueAdminNumberUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.ResetAdminPasswordByMasterUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.UpdateAdminNumberUseCase;
+import com.yd.vibecode.global.annotation.CurrentUser;
+import com.yd.vibecode.global.common.BaseResponse;
+import com.yd.vibecode.global.swagger.AdminNumberApi;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/admin-numbers")
+public class AdminNumberController implements AdminNumberApi {
+
+    private final IssueAdminNumberUseCase issueAdminNumberUseCase;
+    private final UpdateAdminNumberUseCase updateAdminNumberUseCase;
+    private final GetAllAdminsUseCase getAllAdminsUseCase;
+    private final ResetAdminPasswordByMasterUseCase resetAdminPasswordByMasterUseCase;
+
+    @GetMapping("/admins")
+    @Override
+    public BaseResponse<AdminListResponse> getAllAdmins(@CurrentUser String adminId) {
+        AdminListResponse response = getAllAdminsUseCase.execute(Long.parseLong(adminId));
+        return BaseResponse.onSuccess(response);
+    }
+
+    @PostMapping
+    @Override
+    public BaseResponse<AdminNumberResponse> issueAdminNumber(@CurrentUser String adminId,
+                                                              @Valid @RequestBody AdminNumberIssueRequest request) {
+        AdminNumberResponse response = issueAdminNumberUseCase.execute(Long.parseLong(adminId), request);
+        return BaseResponse.onSuccess(response);
+    }
+
+    @PatchMapping("/{adminNumber}/password/reset")
+    @Override
+    public BaseResponse<ResetAdminPasswordByMasterResponse> resetAdminPasswordByMaster(
+            @CurrentUser String adminId,
+            @PathVariable String adminNumber) {
+        ResetAdminPasswordByMasterResponse response =
+                resetAdminPasswordByMasterUseCase.execute(Long.parseLong(adminId), adminNumber);
+        return BaseResponse.onSuccess(response);
+    }
+
+    @PatchMapping("/{adminNumber}")
+    @Override
+    public BaseResponse<AdminNumberResponse> updateAdminNumber(@CurrentUser String adminId,
+                                                               @PathVariable String adminNumber,
+                                                               @Valid @RequestBody AdminNumberUpdateRequest request) {
+        AdminNumberResponse response = updateAdminNumberUseCase.execute(Long.parseLong(adminId), adminNumber, request);
+        return BaseResponse.onSuccess(response);
+    }
+}
+

--- a/src/main/java/com/yd/vibecode/domain/admin/ui/AdminProblemController.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/ui/AdminProblemController.java
@@ -13,10 +13,12 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.yd.vibecode.domain.admin.application.dto.request.CreateProblemRequest;
+import com.yd.vibecode.domain.admin.application.dto.response.ProblemDetailResponse;
 import com.yd.vibecode.domain.admin.application.dto.response.ProblemResponse;
 import com.yd.vibecode.domain.admin.application.dto.response.ProblemSpecResponse;
 import com.yd.vibecode.domain.admin.application.usecase.CreateProblemUseCase;
 import com.yd.vibecode.domain.admin.application.usecase.DeleteProblemUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.GetProblemDetailUseCase;
 import com.yd.vibecode.domain.admin.application.usecase.GetProblemSpecsUseCase;
 import com.yd.vibecode.domain.admin.application.usecase.GetProblemsUseCase;
 import com.yd.vibecode.global.common.BaseResponse;
@@ -34,6 +36,7 @@ public class AdminProblemController implements AdminProblemApi {
     private final CreateProblemUseCase createProblemUseCase;
     private final DeleteProblemUseCase deleteProblemUseCase;
     private final GetProblemSpecsUseCase getProblemSpecsUseCase;
+    private final GetProblemDetailUseCase getProblemDetailUseCase;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -61,6 +64,13 @@ public class AdminProblemController implements AdminProblemApi {
     @Override
     public BaseResponse<List<ProblemSpecResponse>> getProblemSpecs(@PathVariable Long problemId) {
         List<ProblemSpecResponse> response = getProblemSpecsUseCase.execute(problemId);
+        return BaseResponse.onSuccess(response);
+    }
+
+    @GetMapping("/{problemId}/detail")
+    @Override
+    public BaseResponse<ProblemDetailResponse> getProblemDetail(@PathVariable Long problemId) {
+        ProblemDetailResponse response = getProblemDetailUseCase.execute(problemId);
         return BaseResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/auth/application/dto/request/AdminSignupRequest.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/application/dto/request/AdminSignupRequest.java
@@ -2,10 +2,15 @@ package com.yd.vibecode.domain.auth.application.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record AdminSignupRequest(
     @NotBlank(message = "관리자 번호는 필수입니다.")
     String adminNumber,
+
+    @NotBlank(message = "관리자 이름은 필수입니다.")
+    @Size(max = 100, message = "관리자 이름은 100자 이하여야 합니다.")
+    String displayName,
 
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/com/yd/vibecode/domain/auth/application/dto/response/MeResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/application/dto/response/MeResponse.java
@@ -12,7 +12,9 @@ public record MeResponse(
     public record ParticipantInfo(
         Long id,
         String name,
-        String phone
+        String phone,
+        /** ADMIN 전용. USER는 null */
+        String adminNumber
     ) {
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/auth/application/dto/response/MeResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/application/dto/response/MeResponse.java
@@ -11,10 +11,13 @@ public record MeResponse(
 ) {
     public record ParticipantInfo(
         Long id,
+        /** 표시용 이름 (displayName 없으면 adminNumber 등 BE fallback) */
         String name,
         String phone,
         /** ADMIN 전용. USER는 null */
-        String adminNumber
+        String adminNumber,
+        /** ADMIN 전용 원본 display_name (nullable). USER는 null */
+        String displayName
     ) {
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/auth/application/usecase/AdminLoginUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/application/usecase/AdminLoginUseCase.java
@@ -20,7 +20,7 @@ public class AdminLoginUseCase {
     private final AdminService adminService;
     private final TokenProvider tokenProvider;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public AdminLoginResponse execute(AdminLoginRequest request) {
         // 1. 관리자 조회 (관리자 번호 또는 이메일로)
         Admin admin;
@@ -35,14 +35,17 @@ public class AdminLoginUseCase {
             throw new RestApiException(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE);
         }
 
-        // 3. 비밀번호 검증
+        // 3. 비밀번호 검증 (실패 시 예외 — lastLoginAt 미갱신)
         adminService.validatePassword(admin, request.password());
 
-        // 4. JWT 토큰 생성
+        // 4. 인증 성공 시 최근 로그인 시각 저장
+        adminService.recordLastLogin(admin);
+
+        // 5. JWT 토큰 생성
         String accessToken = tokenProvider.createAccessToken(
                 admin.getId().toString(), "ADMIN");
 
-        // 5. 응답 생성
+        // 6. 응답 생성
         return new AdminLoginResponse(
                 accessToken,
                 "ADMIN",

--- a/src/main/java/com/yd/vibecode/domain/auth/application/usecase/AdminSignupUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/application/usecase/AdminSignupUseCase.java
@@ -36,7 +36,11 @@ public class AdminSignupUseCase {
         String passwordHash = adminService.encodePassword(request.password());
 
         // 4. 관리자 생성
-        var admin = adminService.create(request.adminNumber(), request.email(), passwordHash);
+        var admin = adminService.create(
+                request.adminNumber(),
+                request.displayName(),
+                request.email(),
+                passwordHash);
 
         // 5. 관리자 번호 사용 처리
         adminNumberService.assign(adminNumber, admin.getId());

--- a/src/main/java/com/yd/vibecode/domain/auth/application/usecase/MeUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/application/usecase/MeUseCase.java
@@ -56,7 +56,8 @@ public class MeUseCase {
                             admin.getId(),
                             admin.resolveDisplayName(),
                             admin.getEmail(),
-                            admin.getAdminNumber()
+                            admin.getAdminNumber(),
+                            admin.getDisplayName()
                     ),
                     null,
                     null
@@ -81,6 +82,7 @@ public class MeUseCase {
                             user.getId(),
                             user.getName(),
                             user.getPhone(),
+                            null,
                             null
                     ),
                     new ExamInfoResponse(
@@ -102,6 +104,7 @@ public class MeUseCase {
                         user.getId(),
                         user.getName(),
                         user.getPhone(),
+                        null,
                         null
                 ),
                 null,

--- a/src/main/java/com/yd/vibecode/domain/auth/application/usecase/MeUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/application/usecase/MeUseCase.java
@@ -54,8 +54,9 @@ public class MeUseCase {
                     role,
                     new MeResponse.ParticipantInfo(
                             admin.getId(),
-                            admin.getAdminNumber(),  // name 필드에 adminNumber 사용
-                            admin.getEmail()         // phone 필드에 email 사용
+                            admin.resolveDisplayName(),
+                            admin.getEmail(),
+                            admin.getAdminNumber()
                     ),
                     null,
                     null
@@ -79,7 +80,8 @@ public class MeUseCase {
                     new MeResponse.ParticipantInfo(
                             user.getId(),
                             user.getName(),
-                            user.getPhone()
+                            user.getPhone(),
+                            null
                     ),
                     new ExamInfoResponse(
                             exam.getId(),
@@ -99,7 +101,8 @@ public class MeUseCase {
                 new MeResponse.ParticipantInfo(
                         user.getId(),
                         user.getName(),
-                        user.getPhone()
+                        user.getPhone(),
+                        null
                 ),
                 null,
                 null

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/entity/Admin.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/entity/Admin.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +29,9 @@ public class Admin extends BaseEntity {
     @Column(nullable = false, unique = true, length = 50)
     private String adminNumber;
 
+    @Column(name = "display_name", length = 100)
+    private String displayName;
+
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
@@ -44,9 +48,14 @@ public class Admin extends BaseEntity {
     @Column(nullable = false)
     private Boolean isActive = true;
 
+    @Column(name = "last_login_at")
+    private LocalDateTime lastLoginAt;
+
     @Builder
-    public Admin(String adminNumber, String email, String passwordHash, AdminRole role, Boolean is2faEnabled, Boolean isActive) {
+    public Admin(String adminNumber, String displayName, String email, String passwordHash, AdminRole role,
+                 Boolean is2faEnabled, Boolean isActive) {
         this.adminNumber = adminNumber;
+        this.displayName = displayName;
         this.email = email;
         this.passwordHash = passwordHash;
         this.role = role != null ? role : AdminRole.ADMIN;
@@ -64,6 +73,18 @@ public class Admin extends BaseEntity {
 
     public void updateActive(Boolean isActive) {
         this.isActive = isActive != null ? isActive : true;
+    }
+
+    public void updateLastLoginAt(LocalDateTime lastLoginAt) {
+        this.lastLoginAt = lastLoginAt;
+    }
+
+    /** 표시 이름 (미입력·레거시 계정은 관리자 번호) */
+    public String resolveDisplayName() {
+        if (displayName != null && !displayName.isBlank()) {
+            return displayName.trim();
+        }
+        return adminNumber;
     }
 
     public boolean isMaster() {

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/repository/AdminNumberRepository.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/repository/AdminNumberRepository.java
@@ -1,12 +1,16 @@
 package com.yd.vibecode.domain.auth.domain.repository;
 
 import com.yd.vibecode.domain.auth.domain.entity.AdminNumber;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AdminNumberRepository extends JpaRepository<AdminNumber, Long> {
 
     Optional<AdminNumber> findByAdminNumber(String adminNumber);
+
+    List<AdminNumber> findByAdminNumberIn(Collection<String> adminNumbers);
 
     boolean existsByAdminNumber(String adminNumber);
 }

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/repository/AdminRepository.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/repository/AdminRepository.java
@@ -1,5 +1,7 @@
 package com.yd.vibecode.domain.auth.domain.repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,6 +9,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.yd.vibecode.domain.auth.domain.entity.Admin;
 
 public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    List<Admin> findByIdIn(Collection<Long> ids);
 
     Optional<Admin> findByAdminNumber(String adminNumber);
 

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminService.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminService.java
@@ -1,5 +1,7 @@
 package com.yd.vibecode.domain.auth.domain.service;
 
+import java.time.LocalDateTime;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -51,9 +53,10 @@ public class AdminService {
         }
     }
 
-    public Admin create(String adminNumber, String email, String passwordHash) {
+    public Admin create(String adminNumber, String displayName, String email, String passwordHash) {
         Admin admin = Admin.builder()
                 .adminNumber(adminNumber)
+                .displayName(displayName != null ? displayName.trim() : null)
                 .email(email)
                 .passwordHash(passwordHash)
                 .is2faEnabled(false)
@@ -65,6 +68,12 @@ public class AdminService {
 
     public java.util.List<Admin> findAll() {
         return adminRepository.findAll();
+    }
+
+    /** 관리자 로그인 성공 시 최근 로그인 시각 갱신 */
+    public void recordLastLogin(Admin admin) {
+        admin.updateLastLoginAt(LocalDateTime.now());
+        adminRepository.save(admin);
     }
 }
 

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminService.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminService.java
@@ -70,10 +70,9 @@ public class AdminService {
         return adminRepository.findAll();
     }
 
-    /** 관리자 로그인 성공 시 최근 로그인 시각 갱신 */
+    /** 관리자 로그인 성공 시 최근 로그인 시각 갱신 (영속 엔티티 dirty checking) */
     public void recordLastLogin(Admin admin) {
         admin.updateLastLoginAt(LocalDateTime.now());
-        adminRepository.save(admin);
     }
 }
 

--- a/src/main/java/com/yd/vibecode/domain/auth/infrastructure/MasterAdminInitializer.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/infrastructure/MasterAdminInitializer.java
@@ -43,6 +43,7 @@ public class MasterAdminInitializer implements ApplicationRunner {
             log.info("[MasterAdminInitializer] Creating master admin account...");
             Admin master = adminRepository.save(Admin.builder()
                     .adminNumber(properties.adminNumber())
+                    .displayName("Master")
                     .email(properties.email())
                     .passwordHash(passwordEncoder.encode(properties.password()))
                     .role(AdminRole.MASTER)

--- a/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ExamResponse.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/dto/response/ExamResponse.java
@@ -13,14 +13,26 @@ public record ExamResponse(
     LocalDateTime endsAt,
     Integer version,
     Long createdBy,
+    String creatorName,
     long participantCount,
     long completedCount
 ) {
+    private static final String UNKNOWN_CREATOR = "알 수 없음";
+
     public static ExamResponse from(Exam exam) {
-        return from(exam, 0L, 0L);
+        return from(exam, 0L, 0L, null);
     }
 
     public static ExamResponse from(Exam exam, long participantCount, long completedCount) {
+        return from(exam, participantCount, completedCount, null);
+    }
+
+    public static ExamResponse from(
+            Exam exam,
+            long participantCount,
+            long completedCount,
+            String creatorName
+    ) {
         return new ExamResponse(
             exam.getId(),
             exam.getTitle(),
@@ -29,8 +41,16 @@ public record ExamResponse(
             exam.getEndsAt(),
             exam.getVersion(),
             exam.getCreatedBy(),
+            resolveCreatorName(creatorName),
             participantCount,
             completedCount
         );
+    }
+
+    private static String resolveCreatorName(String creatorName) {
+        if (creatorName == null || creatorName.isBlank()) {
+            return UNKNOWN_CREATOR;
+        }
+        return creatorName.trim();
     }
 }

--- a/src/main/java/com/yd/vibecode/global/exception/code/status/AuthErrorStatus.java
+++ b/src/main/java/com/yd/vibecode/global/exception/code/status/AuthErrorStatus.java
@@ -42,7 +42,8 @@ public enum AuthErrorStatus implements BaseCodeInterface {
     ADMIN_NUMBER_INACTIVE(HttpStatus.BAD_REQUEST, "AUTH019", "사용할 수 없는 관리자 번호입니다."),
     MASTER_ONLY(HttpStatus.FORBIDDEN, "AUTH020", "MASTER 권한이 필요합니다."),
     MASTER_ACCOUNT_CANNOT_BE_DEACTIVATED(HttpStatus.BAD_REQUEST, "AUTH021", "마스터 계정은 비활성화할 수 없습니다."),
-    ADMIN_ACCOUNT_INACTIVE(HttpStatus.FORBIDDEN, "AUTH022", "비활성화된 관리자 계정입니다.")
+    ADMIN_ACCOUNT_INACTIVE(HttpStatus.FORBIDDEN, "AUTH022", "비활성화된 관리자 계정입니다."),
+    MASTER_ACCOUNT_PASSWORD_CANNOT_BE_RESET(HttpStatus.BAD_REQUEST, "AUTH023", "마스터 계정 비밀번호는 재설정할 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/yd/vibecode/global/swagger/AdminNumberApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/AdminNumberApi.java
@@ -4,6 +4,7 @@ import com.yd.vibecode.domain.admin.application.dto.request.AdminNumberIssueRequ
 import com.yd.vibecode.domain.admin.application.dto.request.AdminNumberUpdateRequest;
 import com.yd.vibecode.domain.admin.application.dto.response.AdminListResponse;
 import com.yd.vibecode.domain.admin.application.dto.response.AdminNumberResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.ResetAdminPasswordByMasterResponse;
 import com.yd.vibecode.global.common.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,11 +26,18 @@ public interface AdminNumberApi extends BaseApi {
             @Parameter(hidden = true) String adminId,
             AdminNumberIssueRequest request);
 
+    @Operation(
+            summary = "관리자 임시 비밀번호 재설정 (MASTER)",
+            description = "MASTER가 다른 관리자의 비밀번호를 임시 비밀번호로 재설정합니다. " +
+                    "응답의 temporaryPassword는 한 번만 표시됩니다. 마스터 계정은 재설정할 수 없습니다."
+    )
+    BaseResponse<ResetAdminPasswordByMasterResponse> resetAdminPasswordByMaster(
+            @Parameter(hidden = true) String adminId,
+            String adminNumber);
+
     @Operation(summary = "관리자 번호 상태 변경", description = "관리자 번호의 라벨, 만료일, 활성 상태를 변경합니다. 관리자 번호 값 자체는 변경되지 않습니다.")
     BaseResponse<AdminNumberResponse> updateAdminNumber(
             @Parameter(hidden = true) String adminId,
             String adminNumber,
             AdminNumberUpdateRequest request);
 }
-
-

--- a/src/main/java/com/yd/vibecode/global/swagger/AdminProblemApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/AdminProblemApi.java
@@ -3,6 +3,7 @@ package com.yd.vibecode.global.swagger;
 import java.util.List;
 
 import com.yd.vibecode.domain.admin.application.dto.request.CreateProblemRequest;
+import com.yd.vibecode.domain.admin.application.dto.response.ProblemDetailResponse;
 import com.yd.vibecode.domain.admin.application.dto.response.ProblemResponse;
 import com.yd.vibecode.domain.admin.application.dto.response.ProblemSpecResponse;
 import com.yd.vibecode.global.common.BaseResponse;
@@ -31,4 +32,12 @@ public interface AdminProblemApi extends BaseApi {
     @Operation(summary = "문제 스펙 조회", description = "특정 문제의 스펙 목록을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     BaseResponse<List<ProblemSpecResponse>> getProblemSpecs(Long problemId);
+
+    @Operation(
+            summary = "문제 상세 조회",
+            description = "problemId 기준으로 공개 가능한 문제 본문(contentMd) 및 스펙 메타를 조회합니다. "
+                    + "테스트케이스·정답 데이터는 포함하지 않습니다."
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    BaseResponse<ProblemDetailResponse> getProblemDetail(Long problemId);
 }

--- a/src/main/java/com/yd/vibecode/global/util/TemporaryPasswordGenerator.java
+++ b/src/main/java/com/yd/vibecode/global/util/TemporaryPasswordGenerator.java
@@ -1,0 +1,48 @@
+package com.yd.vibecode.global.util;
+
+import java.security.SecureRandom;
+import org.springframework.stereotype.Component;
+
+/**
+ * 마스터가 타 관리자 비밀번호를 재설정할 때 사용하는 임시 비밀번호 생성기.
+ */
+@Component
+public class TemporaryPasswordGenerator {
+
+    private static final String UPPER = "ABCDEFGHJKLMNPQRSTUVWXYZ";
+    private static final String LOWER = "abcdefghjkmnpqrstuvwxyz";
+    private static final String DIGITS = "23456789";
+    private static final String SPECIAL = "!@#$%&*";
+    private static final int PASSWORD_LENGTH = 12;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public String generate() {
+        char[] password = new char[PASSWORD_LENGTH];
+        password[0] = randomChar(UPPER);
+        password[1] = randomChar(LOWER);
+        password[2] = randomChar(DIGITS);
+        password[3] = randomChar(SPECIAL);
+
+        String all = UPPER + LOWER + DIGITS + SPECIAL;
+        for (int i = 4; i < PASSWORD_LENGTH; i++) {
+            password[i] = randomChar(all);
+        }
+
+        shuffle(password);
+        return new String(password);
+    }
+
+    private char randomChar(String alphabet) {
+        return alphabet.charAt(secureRandom.nextInt(alphabet.length()));
+    }
+
+    private void shuffle(char[] array) {
+        for (int i = array.length - 1; i > 0; i--) {
+            int j = secureRandom.nextInt(i + 1);
+            char tmp = array[i];
+            array[i] = array[j];
+            array[j] = tmp;
+        }
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/admin/application/usecase/GetExamsUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/application/usecase/GetExamsUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.yd.vibecode.domain.admin.application.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -14,6 +15,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.entity.AdminRole;
+import com.yd.vibecode.domain.auth.domain.repository.AdminRepository;
 import com.yd.vibecode.domain.exam.application.dto.response.ExamResponse;
 import com.yd.vibecode.domain.exam.domain.entity.Exam;
 import com.yd.vibecode.domain.exam.domain.entity.ExamState;
@@ -30,6 +34,8 @@ class GetExamsUseCaseTest {
     private ExamParticipantRepository examParticipantRepository;
     @Mock
     private SubmissionRepository submissionRepository;
+    @Mock
+    private AdminRepository adminRepository;
 
     @InjectMocks
     private GetExamsUseCase getExamsUseCase;
@@ -65,12 +71,23 @@ class GetExamsUseCaseTest {
             .willReturn(List.of(new Object[]{1L, 3L}, new Object[]{2L, 5L}));
         given(submissionRepository.countGroupByExamIdIn(examIds))
             .willReturn(List.of(new Object[]{1L, 1L}, new Object[]{2L, 4L}));
+        Admin creator = Admin.builder()
+            .adminNumber("ADM-001")
+            .displayName("김관리")
+            .email("admin@test.com")
+            .passwordHash("hash")
+            .role(AdminRole.ADMIN)
+            .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(creator, "id", 1L);
+        given(adminRepository.findByIdIn(any())).willReturn(List.of(creator));
 
         // when
         List<ExamResponse> result = getExamsUseCase.execute();
 
         // then
         assertThat(result).hasSize(2);
+        assertThat(result.get(0).creatorName()).isEqualTo("김관리");
+        assertThat(result.get(1).creatorName()).isEqualTo("김관리");
         assertThat(result.get(0).title()).isEqualTo("Test Exam 1");
         assertThat(result.get(0).state()).isEqualTo(ExamState.WAITING);
         assertThat(result.get(0).participantCount()).isEqualTo(3L);
@@ -82,6 +99,32 @@ class GetExamsUseCaseTest {
         verify(examRepository).findAll();
         verify(examParticipantRepository).countGroupByExamIdIn(examIds);
         verify(submissionRepository).countGroupByExamIdIn(examIds);
+        verify(adminRepository).findByIdIn(any());
+    }
+
+    @Test
+    @DisplayName("생성 관리자가 DB에 없으면 creatorName은 알 수 없음")
+    void execute_missingAdmin_usesUnknownCreatorLabel() {
+        Exam exam = Exam.builder()
+            .title("Orphan Exam")
+            .state(ExamState.WAITING)
+            .startsAt(LocalDateTime.now().plusHours(1))
+            .endsAt(LocalDateTime.now().plusHours(2))
+            .version(0)
+            .createdBy(99L)
+            .build();
+        org.springframework.test.util.ReflectionTestUtils.setField(exam, "id", 9L);
+
+        given(examRepository.findAll()).willReturn(List.of(exam));
+        given(examParticipantRepository.countGroupByExamIdIn(List.of(9L)))
+            .willReturn(List.of());
+        given(submissionRepository.countGroupByExamIdIn(List.of(9L))).willReturn(List.of());
+        given(adminRepository.findByIdIn(any())).willReturn(List.of());
+
+        List<ExamResponse> result = getExamsUseCase.execute();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).creatorName()).isEqualTo("알 수 없음");
     }
 
     @Test

--- a/src/test/java/com/yd/vibecode/domain/admin/application/usecase/ResetAdminPasswordByMasterUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/application/usecase/ResetAdminPasswordByMasterUseCaseTest.java
@@ -1,0 +1,111 @@
+package com.yd.vibecode.domain.admin.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.yd.vibecode.domain.admin.domain.service.AdminAuditLogService;
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.entity.AdminRole;
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+import com.yd.vibecode.global.util.TemporaryPasswordGenerator;
+
+@ExtendWith(MockitoExtension.class)
+class ResetAdminPasswordByMasterUseCaseTest {
+
+    @InjectMocks
+    private ResetAdminPasswordByMasterUseCase resetAdminPasswordByMasterUseCase;
+
+    @Mock
+    private AdminService adminService;
+
+    @Mock
+    private AdminAuditLogService adminAuditLogService;
+
+    @Mock
+    private TemporaryPasswordGenerator temporaryPasswordGenerator;
+
+    @Test
+    @DisplayName("MASTER가 타 관리자 임시 비밀번호 재설정 성공")
+    void execute_success() {
+        Long requesterId = 1L;
+        String adminNumber = "ADM-123456";
+        String temporaryPassword = "TempPass1!xYz";
+
+        Admin requester = Admin.builder()
+                .role(AdminRole.MASTER)
+                .build();
+        Admin target = Admin.builder()
+                .adminNumber(adminNumber)
+                .passwordHash("oldHash")
+                .role(AdminRole.ADMIN)
+                .build();
+        ReflectionTestUtils.setField(target, "id", 2L);
+
+        given(adminService.findById(requesterId)).willReturn(requester);
+        given(adminService.findByAdminNumber(adminNumber)).willReturn(target);
+        given(temporaryPasswordGenerator.generate()).willReturn(temporaryPassword);
+        given(adminService.encodePassword(temporaryPassword)).willReturn("encodedNew");
+
+        var response = resetAdminPasswordByMasterUseCase.execute(requesterId, adminNumber);
+
+        assertThat(response.temporaryPassword()).isEqualTo(temporaryPassword);
+        assertThat(target.getPasswordHash()).isEqualTo("encodedNew");
+        verify(adminService).encodePassword(temporaryPassword);
+        verify(adminAuditLogService).log(eq(requesterId), eq("RESET_PASSWORD_BY_MASTER"), any());
+    }
+
+    @Test
+    @DisplayName("MASTER가 아니면 비밀번호 재설정 불가")
+    void execute_fail_not_master() {
+        Long requesterId = 1L;
+        Admin requester = Admin.builder().role(AdminRole.ADMIN).build();
+
+        given(adminService.findById(requesterId)).willReturn(requester);
+
+        assertThatThrownBy(() -> resetAdminPasswordByMasterUseCase.execute(requesterId, "ADM-1"))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> {
+                    RestApiException exception = (RestApiException) ex;
+                    assertThat(exception.getErrorCode().getCode())
+                            .isEqualTo(AuthErrorStatus.MASTER_ONLY.getCode().getCode());
+                });
+    }
+
+    @Test
+    @DisplayName("마스터 계정 비밀번호 재설정 불가")
+    void execute_fail_target_is_master() {
+        Long requesterId = 1L;
+        String adminNumber = "MASTER-0001";
+
+        Admin requester = Admin.builder().role(AdminRole.MASTER).build();
+        Admin target = Admin.builder()
+                .adminNumber(adminNumber)
+                .role(AdminRole.MASTER)
+                .build();
+
+        given(adminService.findById(requesterId)).willReturn(requester);
+        given(adminService.findByAdminNumber(adminNumber)).willReturn(target);
+
+        assertThatThrownBy(() -> resetAdminPasswordByMasterUseCase.execute(requesterId, adminNumber))
+                .isInstanceOf(RestApiException.class)
+                .satisfies(ex -> {
+                    RestApiException exception = (RestApiException) ex;
+                    assertThat(exception.getErrorCode().getCode())
+                            .isEqualTo(AuthErrorStatus.MASTER_ACCOUNT_PASSWORD_CANNOT_BE_RESET.getCode().getCode());
+                });
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/admin/ui/AdminNumberControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/ui/AdminNumberControllerTest.java
@@ -1,132 +1,163 @@
-package com.yd.vibecode.domain.admin.ui;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MockMvc;
-
-import com.yd.vibecode.domain.admin.application.dto.response.AdminListResponse;
-import com.yd.vibecode.domain.admin.application.dto.response.AdminNumberResponse;
-import com.yd.vibecode.domain.admin.application.usecase.GetAllAdminsUseCase;
-import com.yd.vibecode.domain.admin.application.usecase.IssueAdminNumberUseCase;
-import com.yd.vibecode.domain.admin.application.usecase.UpdateAdminNumberUseCase;
-import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
-import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
-import com.yd.vibecode.global.security.SecurityConfig;
-import com.yd.vibecode.global.security.TokenProvider;
-
-@WebMvcTest(
-    controllers = AdminNumberController.class,
-    excludeAutoConfiguration = SecurityAutoConfiguration.class,
-    excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
-)
-class AdminNumberControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private IssueAdminNumberUseCase issueAdminNumberUseCase;
-
-    @MockBean
-    private UpdateAdminNumberUseCase updateAdminNumberUseCase;
-
-    @MockBean
-    private GetAllAdminsUseCase getAllAdminsUseCase;
-
-    @MockBean
-    private JwtBlacklistInterceptor jwtBlacklistInterceptor;
-
-    @MockBean
-    private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
-
-    @MockBean
-    private TokenProvider tokenProvider;
-
-    @Test
-    @DisplayName("모든 관리자 조회 성공")
-    @WithMockUser(roles = "ADMIN")
-    void getAllAdmins_success() throws Exception {
-        // given
-        AdminListResponse mockResponse = new AdminListResponse(List.of());
-        given(getAllAdminsUseCase.execute(any(Long.class)))
-            .willReturn(mockResponse);
-
-        // when & then
-        mockMvc.perform(get("/api/admin/admin-numbers/admins"))
-            .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("관리자 번호 발급 성공")
-    @WithMockUser(roles = "ADMIN")
-    void issueAdminNumber_success() throws Exception {
-        // given
-        String requestBody = """
-            {
-                "label": "Test Admin",
-                "expiresAt": "2025-12-31T23:59:59"
-            }
-            """;
-
-        AdminNumberResponse mockResponse = new AdminNumberResponse(
-            "ADM-123456", "Test Admin", true, 1L, null,
-            LocalDateTime.parse("2025-12-31T23:59:59"), null, LocalDateTime.now()
-        );
-
-        given(issueAdminNumberUseCase.execute(any(Long.class), any()))
-            .willReturn(mockResponse);
-
-        // when & then
-        mockMvc.perform(post("/api/admin/admin-numbers")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody))
-            .andExpect(status().isOk());
-    }
-
-    @Test
-    @DisplayName("관리자 번호 수정 성공")
-    @WithMockUser(roles = "ADMIN")
-    void updateAdminNumber_success() throws Exception {
-        // given
-        String adminNumber = "ADM-123456";
-        String requestBody = """
-            {
-                "label": "Updated Admin",
-                "active": false
-            }
-            """;
-
-        AdminNumberResponse mockResponse = new AdminNumberResponse(
-            adminNumber, "Updated Admin", false, 1L, null, null, null, LocalDateTime.now()
-        );
-
-        given(updateAdminNumberUseCase.execute(any(Long.class), eq(adminNumber), any()))
-            .willReturn(mockResponse);
-
-        // when & then
-        mockMvc.perform(patch("/api/admin/admin-numbers/" + adminNumber)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody))
-            .andExpect(status().isOk());
-    }
-}
+package com.yd.vibecode.domain.admin.ui;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.yd.vibecode.domain.admin.application.dto.response.AdminListResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.AdminNumberResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.ResetAdminPasswordByMasterResponse;
+import com.yd.vibecode.domain.admin.application.usecase.GetAllAdminsUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.IssueAdminNumberUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.ResetAdminPasswordByMasterUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.UpdateAdminNumberUseCase;
+import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
+import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
+import com.yd.vibecode.global.security.SecurityConfig;
+import com.yd.vibecode.global.security.TokenProvider;
+
+@WebMvcTest(
+    controllers = AdminNumberController.class,
+    excludeAutoConfiguration = SecurityAutoConfiguration.class,
+    excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+)
+class AdminNumberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private IssueAdminNumberUseCase issueAdminNumberUseCase;
+
+    @MockBean
+    private UpdateAdminNumberUseCase updateAdminNumberUseCase;
+
+    @MockBean
+    private GetAllAdminsUseCase getAllAdminsUseCase;
+
+    @MockBean
+    private ResetAdminPasswordByMasterUseCase resetAdminPasswordByMasterUseCase;
+
+    @MockBean
+    private JwtBlacklistInterceptor jwtBlacklistInterceptor;
+
+    @MockBean
+    private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @Test
+    @DisplayName("모든 관리자 조회 성공")
+    @WithMockUser(roles = "ADMIN")
+    void getAllAdmins_success() throws Exception {
+        AdminListResponse mockResponse = new AdminListResponse(List.of());
+        given(getAllAdminsUseCase.execute(any(Long.class)))
+            .willReturn(mockResponse);
+
+        mockMvc.perform(get("/api/admin/admin-numbers/admins"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("관리자 번호 발급 성공")
+    @WithMockUser(roles = "ADMIN")
+    void issueAdminNumber_success() throws Exception {
+        String requestBody = """
+            {
+                "label": "Test Admin",
+                "expiresAt": "2025-12-31T23:59:59"
+            }
+            """;
+
+        AdminNumberResponse mockResponse = new AdminNumberResponse(
+            "ADM-123456", "Test Admin", true, 1L, null,
+            LocalDateTime.parse("2025-12-31T23:59:59"), null, LocalDateTime.now()
+        );
+
+        given(issueAdminNumberUseCase.execute(any(Long.class), any()))
+            .willReturn(mockResponse);
+
+        mockMvc.perform(post("/api/admin/admin-numbers")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("관리자 번호 수정 성공")
+    @WithMockUser(roles = "ADMIN")
+    void updateAdminNumber_success() throws Exception {
+        String adminNumber = "ADM-123456";
+        String requestBody = """
+            {
+                "label": "Updated Admin",
+                "active": false
+            }
+            """;
+
+        AdminNumberResponse mockResponse = new AdminNumberResponse(
+            adminNumber, "Updated Admin", false, 1L, null, null, null, LocalDateTime.now()
+        );
+
+        given(updateAdminNumberUseCase.execute(any(Long.class), eq(adminNumber), any()))
+            .willReturn(mockResponse);
+
+        mockMvc.perform(patch("/api/admin/admin-numbers/" + adminNumber)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("MASTER 타 관리자 임시 비밀번호 재설정 성공")
+    @WithMockUser(roles = "ADMIN")
+    void resetAdminPasswordByMaster_success() throws Exception {
+        String adminNumber = "ADM-123456";
+
+        given(jwtBlacklistInterceptor.preHandle(
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class),
+                any()
+        )).willReturn(true);
+        given(tokenProvider.getToken(any(HttpServletRequest.class))).willReturn(Optional.of("access-token"));
+        given(tokenProvider.isAccessToken("access-token")).willReturn(true);
+        given(tokenProvider.getId("access-token")).willReturn(Optional.of("1"));
+
+        given(resetAdminPasswordByMasterUseCase.execute(eq(1L), eq(adminNumber)))
+                .willReturn(new ResetAdminPasswordByMasterResponse("TempPass1!xYz"));
+
+        mockMvc.perform(patch("/api/admin/admin-numbers/" + adminNumber + "/password/reset"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.temporaryPassword").value("TempPass1!xYz"));
+
+        verify(resetAdminPasswordByMasterUseCase).execute(eq(1L), eq(adminNumber));
+        verify(updateAdminNumberUseCase, never()).execute(any(Long.class), eq(adminNumber), any());
+    }
+}
+

--- a/src/test/java/com/yd/vibecode/domain/admin/ui/AdminNumberControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/ui/AdminNumberControllerTest.java
@@ -12,11 +12,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +50,10 @@ import com.yd.vibecode.global.security.TokenProvider;
 )
 class AdminNumberControllerTest {
 
+    private static final String ACCESS_TOKEN = "access-token";
+    /** JWT @CurrentUser로 전달되는 요청자(MASTER) ID */
+    private static final Long CURRENT_USER_ID = 1L;
+
     @Autowired
     private MockMvc mockMvc;
 
@@ -72,47 +78,64 @@ class AdminNumberControllerTest {
     @MockBean
     private TokenProvider tokenProvider;
 
-    @Test
-    @DisplayName("모든 관리자 조회 성공")
-    @WithMockUser(roles = "ADMIN")
-    void getAllAdmins_success() throws Exception {
-        AdminListResponse mockResponse = new AdminListResponse(List.of());
-        given(getAllAdminsUseCase.execute(any(Long.class)))
-            .willReturn(mockResponse);
-
-        mockMvc.perform(get("/api/admin/admin-numbers/admins"))
-            .andExpect(status().isOk());
+    @BeforeEach
+    void setUp() throws Exception {
+        given(jwtBlacklistInterceptor.preHandle(
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class),
+                any()
+        )).willReturn(true);
+        given(excludeBlacklistPathProperties.getExcludeAuthPaths()).willReturn(Collections.emptyList());
+        given(tokenProvider.getToken(any(HttpServletRequest.class))).willReturn(Optional.of(ACCESS_TOKEN));
+        given(tokenProvider.isAccessToken(ACCESS_TOKEN)).willReturn(true);
+        given(tokenProvider.getId(ACCESS_TOKEN)).willReturn(Optional.of(String.valueOf(CURRENT_USER_ID)));
     }
 
     @Test
-    @DisplayName("관리자 번호 발급 성공")
-    @WithMockUser(roles = "ADMIN")
-    void issueAdminNumber_success() throws Exception {
+    @DisplayName("MASTER - 모든 관리자 조회 성공")
+    @WithMockUser(roles = "MASTER")
+    void master_getAllAdmins_success() throws Exception {
+        AdminListResponse mockResponse = new AdminListResponse(List.of());
+        given(getAllAdminsUseCase.execute(eq(CURRENT_USER_ID))).willReturn(mockResponse);
+
+        mockMvc.perform(get("/api/admin/admin-numbers/admins")
+                .header("Authorization", "Bearer " + ACCESS_TOKEN))
+            .andExpect(status().isOk());
+
+        verify(getAllAdminsUseCase).execute(eq(CURRENT_USER_ID));
+    }
+
+    @Test
+    @DisplayName("MASTER - 관리자 번호 발급 성공")
+    @WithMockUser(roles = "MASTER")
+    void master_issueAdminNumber_success() throws Exception {
         String requestBody = """
             {
                 "label": "Test Admin",
-                "expiresAt": "2025-12-31T23:59:59"
+                "expiresAt": "2099-12-31T23:59:59"
             }
             """;
 
         AdminNumberResponse mockResponse = new AdminNumberResponse(
             "ADM-123456", "Test Admin", true, 1L, null,
-            LocalDateTime.parse("2025-12-31T23:59:59"), null, LocalDateTime.now()
+            LocalDateTime.parse("2099-12-31T23:59:59"), null, LocalDateTime.now()
         );
 
-        given(issueAdminNumberUseCase.execute(any(Long.class), any()))
-            .willReturn(mockResponse);
+        given(issueAdminNumberUseCase.execute(eq(CURRENT_USER_ID), any())).willReturn(mockResponse);
 
         mockMvc.perform(post("/api/admin/admin-numbers")
+                .header("Authorization", "Bearer " + ACCESS_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
             .andExpect(status().isOk());
+
+        verify(issueAdminNumberUseCase).execute(eq(CURRENT_USER_ID), any());
     }
 
     @Test
-    @DisplayName("관리자 번호 수정 성공")
-    @WithMockUser(roles = "ADMIN")
-    void updateAdminNumber_success() throws Exception {
+    @DisplayName("MASTER - 관리자 번호 수정 성공")
+    @WithMockUser(roles = "MASTER")
+    void master_updateAdminNumber_success() throws Exception {
         String adminNumber = "ADM-123456";
         String requestBody = """
             {
@@ -125,39 +148,33 @@ class AdminNumberControllerTest {
             adminNumber, "Updated Admin", false, 1L, null, null, null, LocalDateTime.now()
         );
 
-        given(updateAdminNumberUseCase.execute(any(Long.class), eq(adminNumber), any()))
+        given(updateAdminNumberUseCase.execute(eq(CURRENT_USER_ID), eq(adminNumber), any()))
             .willReturn(mockResponse);
 
         mockMvc.perform(patch("/api/admin/admin-numbers/" + adminNumber)
+                .header("Authorization", "Bearer " + ACCESS_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
             .andExpect(status().isOk());
+
+        verify(updateAdminNumberUseCase).execute(eq(CURRENT_USER_ID), eq(adminNumber), any());
     }
 
     @Test
-    @DisplayName("MASTER 타 관리자 임시 비밀번호 재설정 성공")
-    @WithMockUser(roles = "ADMIN")
-    void resetAdminPasswordByMaster_success() throws Exception {
+    @DisplayName("MASTER - 타 관리자 임시 비밀번호 재설정 성공")
+    @WithMockUser(roles = "MASTER")
+    void master_resetAdminPasswordByMaster_success() throws Exception {
         String adminNumber = "ADM-123456";
 
-        given(jwtBlacklistInterceptor.preHandle(
-                any(HttpServletRequest.class),
-                any(HttpServletResponse.class),
-                any()
-        )).willReturn(true);
-        given(tokenProvider.getToken(any(HttpServletRequest.class))).willReturn(Optional.of("access-token"));
-        given(tokenProvider.isAccessToken("access-token")).willReturn(true);
-        given(tokenProvider.getId("access-token")).willReturn(Optional.of("1"));
-
-        given(resetAdminPasswordByMasterUseCase.execute(eq(1L), eq(adminNumber)))
+        given(resetAdminPasswordByMasterUseCase.execute(eq(CURRENT_USER_ID), eq(adminNumber)))
                 .willReturn(new ResetAdminPasswordByMasterResponse("TempPass1!xYz"));
 
-        mockMvc.perform(patch("/api/admin/admin-numbers/" + adminNumber + "/password/reset"))
+        mockMvc.perform(patch("/api/admin/admin-numbers/" + adminNumber + "/password/reset")
+                .header("Authorization", "Bearer " + ACCESS_TOKEN))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.result.temporaryPassword").value("TempPass1!xYz"));
 
-        verify(resetAdminPasswordByMasterUseCase).execute(eq(1L), eq(adminNumber));
+        verify(resetAdminPasswordByMasterUseCase).execute(eq(CURRENT_USER_ID), eq(adminNumber));
         verify(updateAdminNumberUseCase, never()).execute(any(Long.class), eq(adminNumber), any());
     }
 }
-

--- a/src/test/java/com/yd/vibecode/domain/admin/ui/AdminProblemControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/ui/AdminProblemControllerTest.java
@@ -19,8 +19,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.yd.vibecode.domain.admin.application.usecase.CreateProblemUseCase;
 import com.yd.vibecode.domain.admin.application.usecase.DeleteProblemUseCase;
+import com.yd.vibecode.domain.admin.application.dto.response.ProblemDetailResponse;
+import com.yd.vibecode.domain.admin.application.usecase.GetProblemDetailUseCase;
 import com.yd.vibecode.domain.admin.application.usecase.GetProblemSpecsUseCase;
 import com.yd.vibecode.domain.admin.application.usecase.GetProblemsUseCase;
+import com.yd.vibecode.domain.problem.domain.entity.Difficulty;
+import com.yd.vibecode.domain.problem.domain.entity.ProblemStatus;
 import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
 import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
 import com.yd.vibecode.global.security.SecurityConfig;
@@ -49,6 +53,9 @@ class AdminProblemControllerTest {
     private GetProblemSpecsUseCase getProblemSpecsUseCase;
 
     @MockBean
+    private GetProblemDetailUseCase getProblemDetailUseCase;
+
+    @MockBean
     private JwtBlacklistInterceptor jwtBlacklistInterceptor;
 
     @MockBean
@@ -68,6 +75,33 @@ class AdminProblemControllerTest {
 
         // when & then
         mockMvc.perform(get("/api/admin/problems/" + problemId + "/specs"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("문제 상세 조회 성공")
+    @WithMockUser(roles = "MASTER")
+    void getProblemDetail_success() throws Exception {
+        Long problemId = 1L;
+        ProblemDetailResponse detail = new ProblemDetailResponse(
+            problemId,
+            "외판원 순회",
+            Difficulty.MEDIUM,
+            List.of("dp"),
+            1,
+            "## 문제\n본문",
+            new ProblemDetailResponse.LimitsInfo(2000, 256),
+            new ProblemDetailResponse.RestrictionsInfo(List.of("python3.11"), List.of()),
+            new ProblemDetailResponse.CheckerInfo("equality"),
+            null,
+            null,
+            null,
+            ProblemStatus.PUBLISHED,
+            true
+        );
+        given(getProblemDetailUseCase.execute(eq(problemId))).willReturn(detail);
+
+        mockMvc.perform(get("/api/admin/problems/" + problemId + "/detail"))
             .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/yd/vibecode/domain/auth/application/usecase/AdminLoginUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/application/usecase/AdminLoginUseCaseTest.java
@@ -54,6 +54,7 @@ class AdminLoginUseCaseTest {
         assertThat(response.role()).isEqualTo("ADMIN");
         assertThat(response.admin().email()).isEqualTo("admin@example.com");
         verify(adminService).validatePassword(admin, "password");
+        verify(adminService).recordLastLogin(admin);
     }
 
     @Test
@@ -79,5 +80,6 @@ class AdminLoginUseCaseTest {
         assertThat(response.role()).isEqualTo("ADMIN");
         assertThat(response.admin().adminNumber()).isEqualTo("admin123");
         verify(adminService).validatePassword(admin, "password");
+        verify(adminService).recordLastLogin(admin);
     }
 }

--- a/src/test/java/com/yd/vibecode/domain/auth/application/usecase/AdminSignupUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/application/usecase/AdminSignupUseCaseTest.java
@@ -36,7 +36,7 @@ class AdminSignupUseCaseTest {
     void signup_success() {
         // given
         AdminSignupRequest request = new AdminSignupRequest(
-                "admin123", "admin@example.com", "password");
+                "admin123", "홍길동", "admin@example.com", "password");
         AdminNumber adminNumber = AdminNumber.builder()
                 .adminNumber("admin123")
                 .issuedBy(1L)
@@ -50,7 +50,7 @@ class AdminSignupUseCaseTest {
         given(adminService.existsByAdminNumber(request.adminNumber())).willReturn(false);
         given(adminService.existsByEmail(request.email())).willReturn(false);
         given(adminService.encodePassword(request.password())).willReturn("encodedPassword");
-        given(adminService.create(request.adminNumber(), request.email(), "encodedPassword"))
+        given(adminService.create(request.adminNumber(), request.displayName(), request.email(), "encodedPassword"))
                 .willReturn(savedAdmin);
 
         // when
@@ -58,7 +58,7 @@ class AdminSignupUseCaseTest {
 
         // then
         verify(adminNumberService).assign(adminNumber, savedAdmin.getId());
-        verify(adminService).create(request.adminNumber(), request.email(), "encodedPassword");
+        verify(adminService).create(request.adminNumber(), request.displayName(), request.email(), "encodedPassword");
     }
 
     @Test
@@ -66,7 +66,7 @@ class AdminSignupUseCaseTest {
     void signup_fail_duplicate_admin_number() {
         // given
         AdminSignupRequest request = new AdminSignupRequest(
-                "admin123", "admin@example.com", "password");
+                "admin123", "홍길동", "admin@example.com", "password");
         AdminNumber adminNumber = AdminNumber.builder()
                 .adminNumber("admin123")
                 .issuedBy(1L)
@@ -88,7 +88,7 @@ class AdminSignupUseCaseTest {
     void signup_fail_duplicate_email() {
         // given
         AdminSignupRequest request = new AdminSignupRequest(
-                "admin123", "admin@example.com", "password");
+                "admin123", "홍길동", "admin@example.com", "password");
         AdminNumber adminNumber = AdminNumber.builder()
                 .adminNumber("admin123")
                 .issuedBy(1L)

--- a/src/test/java/com/yd/vibecode/domain/auth/application/usecase/MeUseCaseAdminTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/application/usecase/MeUseCaseAdminTest.java
@@ -1,0 +1,86 @@
+package com.yd.vibecode.domain.auth.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.yd.vibecode.domain.auth.application.dto.response.MeResponse;
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.entity.AdminRole;
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.domain.exam.domain.service.ExamParticipantService;
+import com.yd.vibecode.domain.exam.domain.service.ExamService;
+import com.yd.vibecode.domain.auth.domain.service.UserService;
+import com.yd.vibecode.global.security.TokenProvider;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MeUseCaseAdminTest {
+
+    @InjectMocks
+    private MeUseCase meUseCase;
+
+    @Mock
+    private TokenProvider tokenProvider;
+    @Mock
+    private UserService userService;
+    @Mock
+    private AdminService adminService;
+    @Mock
+    private ExamParticipantService examParticipantService;
+    @Mock
+    private ExamService examService;
+
+    @Test
+    @DisplayName("ADMIN 내 정보 조회 - displayName·adminNumber 분리")
+    void me_admin_returns_display_name_and_admin_number() {
+        String token = "accessToken";
+        Admin admin = Admin.builder()
+                .adminNumber("ADM-001")
+                .displayName("김관리")
+                .email("admin@example.com")
+                .passwordHash("hash")
+                .role(AdminRole.ADMIN)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 1L);
+
+        given(tokenProvider.getId(token)).willReturn(Optional.of("1"));
+        given(tokenProvider.getRole(token)).willReturn(Optional.of("ADMIN"));
+        given(adminService.findById(1L)).willReturn(admin);
+
+        MeResponse response = meUseCase.execute(token);
+
+        assertThat(response.role()).isEqualTo("ADMIN");
+        assertThat(response.participant().name()).isEqualTo("김관리");
+        assertThat(response.participant().phone()).isEqualTo("admin@example.com");
+        assertThat(response.participant().adminNumber()).isEqualTo("ADM-001");
+    }
+
+    @Test
+    @DisplayName("ADMIN 내 정보 조회 - displayName 없으면 adminNumber fallback")
+    void me_admin_fallback_display_name() {
+        String token = "accessToken";
+        Admin admin = Admin.builder()
+                .adminNumber("ADM-002")
+                .email("legacy@example.com")
+                .passwordHash("hash")
+                .role(AdminRole.ADMIN)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 2L);
+
+        given(tokenProvider.getId(token)).willReturn(Optional.of("2"));
+        given(tokenProvider.getRole(token)).willReturn(Optional.of("ADMIN"));
+        given(adminService.findById(2L)).willReturn(admin);
+
+        MeResponse response = meUseCase.execute(token);
+
+        assertThat(response.participant().name()).isEqualTo("ADM-002");
+        assertThat(response.participant().adminNumber()).isEqualTo("ADM-002");
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/auth/application/usecase/MeUseCaseAdminTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/application/usecase/MeUseCaseAdminTest.java
@@ -58,6 +58,7 @@ class MeUseCaseAdminTest {
 
         assertThat(response.role()).isEqualTo("ADMIN");
         assertThat(response.participant().name()).isEqualTo("김관리");
+        assertThat(response.participant().displayName()).isEqualTo("김관리");
         assertThat(response.participant().phone()).isEqualTo("admin@example.com");
         assertThat(response.participant().adminNumber()).isEqualTo("ADM-001");
     }
@@ -81,6 +82,7 @@ class MeUseCaseAdminTest {
         MeResponse response = meUseCase.execute(token);
 
         assertThat(response.participant().name()).isEqualTo("ADM-002");
+        assertThat(response.participant().displayName()).isNull();
         assertThat(response.participant().adminNumber()).isEqualTo("ADM-002");
     }
 }

--- a/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminServiceTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.yd.vibecode.domain.auth.domain.entity.Admin;
@@ -64,6 +65,21 @@ class AdminServiceTest {
 
         // when & then
         assertDoesNotThrow(() -> adminService.validatePassword(admin, "raw"));
+    }
+
+    @Test
+    @DisplayName("최근 로그인 시각 갱신 - save 없이 dirty checking")
+    void recordLastLogin_updatesLastLoginAt_withoutSave() {
+        Admin admin = Admin.builder()
+                .adminNumber("admin123")
+                .email("admin@example.com")
+                .passwordHash("encoded")
+                .build();
+
+        adminService.recordLastLogin(admin);
+
+        assertThat(admin.getLastLoginAt()).isNotNull();
+        verify(adminRepository, never()).save(any(Admin.class));
     }
 
     @Test

--- a/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminServiceTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminServiceTest.java
@@ -48,7 +48,7 @@ class AdminServiceTest {
         given(adminRepository.save(any(Admin.class))).willReturn(admin);
 
         // when
-        Admin result = adminService.create(adminNumber, email, passwordHash);
+        Admin result = adminService.create(adminNumber, "테스트 관리자", email, passwordHash);
 
         // then
         assertThat(result.getAdminNumber()).isEqualTo(adminNumber);

--- a/src/test/java/com/yd/vibecode/global/util/TemporaryPasswordGeneratorTest.java
+++ b/src/test/java/com/yd/vibecode/global/util/TemporaryPasswordGeneratorTest.java
@@ -1,0 +1,33 @@
+package com.yd.vibecode.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+class TemporaryPasswordGeneratorTest {
+
+    private final TemporaryPasswordGenerator generator = new TemporaryPasswordGenerator();
+
+    @RepeatedTest(20)
+    @DisplayName("임시 비밀번호는 12자이며 영문 대/소문자, 숫자, 특수문자를 포함한다")
+    void generate_meetsPolicy() {
+        String password = generator.generate();
+
+        assertThat(password).hasSize(12);
+        assertThat(password).matches(".*[A-Z].*");
+        assertThat(password).matches(".*[a-z].*");
+        assertThat(password).matches(".*[0-9].*");
+        assertThat(password).matches(".*[!@#$%&*].*");
+    }
+
+    @Test
+    @DisplayName("연속 생성 시 서로 다른 비밀번호가 나온다")
+    void generate_isNotConstant() {
+        String first = generator.generate();
+        String second = generator.generate();
+
+        assertThat(first).isNotEqualTo(second);
+    }
+}


### PR DESCRIPTION
## 작업 내용

### Test Sessions 생성자 정보 개선
- 테스트 세션 목록/상세 조회 시 생성자 정보를 실제 관리자 이름 기반으로 반환하도록 개선
- 기존 `"Admin"` 고정값 및 불명확한 fallback 처리 정리
- creatorName 조회 기준 통일
- 관리자 lookup 기반 생성자 정보 매핑 구조 정리

---

### 관리자 정보 응답 구조 개선
- `/api/auth/me` 응답 구조 개선
- `displayName` 필드 추가
- displayName / name / adminNumber 역할 분리
- 관리자 이름과 관리자 번호가 혼동되지 않도록 응답 구조 정리

---

### 관리자 계정 조회 응답 개선
- `/api/admin/admin-numbers/admins` 응답에서 displayName 처리 개선
- 기존:
  - displayName에 fallback(adminNumber)이 섞여 들어가던 문제 존재
- 수정 후:
  - DB 원본 displayName nullable 반환
  - FE에서 명확한 fallback 처리 가능하도록 구조 개선

---

### 참가자 상태 표시 규칙 개선 지원
- 관리자 참가자 목록 상태 계산 로직 정리 지원
- 응시 상태와 제출 상태 간 모순 케이스 대응
- 종료된 응시자에게 `진행 중` 상태가 표시되지 않도록 상태 기준 정리
- 상태 조합 기반 helper 구조 지원

---

### fallback 및 표시 기준 정리
- `"알 수 없음"` fallback 기준 통일
- displayName / adminNumber fallback 우선순위 정리
- 일부 Mock/하드코딩 제거 지원

---

### 테스트 및 안정화
- 관련 테스트 업데이트
  - `GetExamsUseCaseTest`
  - `MeUseCaseAdminTest`
- 기존 제출/채점/토큰 사용량 로직 영향 없이 개선
- 기존 API 구조와의 호환성 유지