### PR TITLE
feat: AI 채점 결과 콜백() — submission_runs 연동

### DIFF
--- a/src/main/java/com/yd/vibecode/domain/chat/ui/AICallbackController.java
+++ b/src/main/java/com/yd/vibecode/domain/chat/ui/AICallbackController.java
@@ -1,33 +1,55 @@
 package com.yd.vibecode.domain.chat.ui;
 
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.yd.vibecode.domain.submission.application.dto.request.AISubmissionStatusRequest;
+import com.yd.vibecode.domain.submission.application.dto.request.ScoringResultRequest;
+import com.yd.vibecode.domain.submission.application.usecase.ReceiveScoringResultUseCase;
 import com.yd.vibecode.domain.submission.application.usecase.UpdateSubmissionStatusUseCase;
 import com.yd.vibecode.global.common.BaseResponse;
 import com.yd.vibecode.global.swagger.AICallbackApi;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * AI Callback Controller
- * - AI 서버로부터 제출 상태 업데이트 수신
+ * - POST /api/callbacks/ai/analysis: 진행/실패 상태만 (RUNNING, FAILED 권장)
+ * - POST /api/callbacks/ai/submissions/{submissionId}/result: 채점 결과 (runs, scores, SSE)
  */
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/callbacks/ai")
 public class AICallbackController implements AICallbackApi {
 
     private final UpdateSubmissionStatusUseCase updateSubmissionStatusUseCase;
+    private final ReceiveScoringResultUseCase receiveScoringResultUseCase;
 
     @Override
     @PostMapping("/analysis")
     public BaseResponse<Void> receiveAnalysisResult(@Valid @RequestBody AISubmissionStatusRequest request) {
+        log.info("[AI Callback] POST /analysis — submissionId={}, status={} (DB status only, no SSE)",
+                request.submissionId(), request.status());
         updateSubmissionStatusUseCase.execute(request.submissionId(), request.status());
+        return BaseResponse.onSuccess();
+    }
+
+    @Override
+    @PostMapping("/submissions/{submissionId}/result")
+    public BaseResponse<Void> receiveScoringResult(
+            @PathVariable Long submissionId,
+            @Valid @RequestBody ScoringResultRequest request) {
+        int testCaseCount = request.testCases() != null ? request.testCases().size() : 0;
+        log.info("[AI Callback] POST /submissions/{}/result — status={}, testCases={}, hasScore={}",
+                submissionId, request.status(), testCaseCount, request.score() != null);
+        receiveScoringResultUseCase.execute(submissionId, request);
+        log.info("[AI Callback] result 처리 완료 — submissionId={}, status={}", submissionId, request.status());
         return BaseResponse.onSuccess();
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/chat/ui/AICallbackController.java
+++ b/src/main/java/com/yd/vibecode/domain/chat/ui/AICallbackController.java
@@ -45,9 +45,8 @@ public class AICallbackController implements AICallbackApi {
     public BaseResponse<Void> receiveScoringResult(
             @PathVariable Long submissionId,
             @Valid @RequestBody ScoringResultRequest request) {
-        int testCaseCount = request.testCases() != null ? request.testCases().size() : 0;
         log.info("[AI Callback] POST /submissions/{}/result — status={}, testCases={}, hasScore={}",
-                submissionId, request.status(), testCaseCount, request.score() != null);
+                submissionId, request.status(), request.testCases().size(), request.score() != null);
         receiveScoringResultUseCase.execute(submissionId, request);
         log.info("[AI Callback] result 처리 완료 — submissionId={}, status={}", submissionId, request.status());
         return BaseResponse.onSuccess();

--- a/src/main/java/com/yd/vibecode/domain/submission/application/dto/request/ScoringResultRequest.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/dto/request/ScoringResultRequest.java
@@ -3,6 +3,9 @@ package com.yd.vibecode.domain.submission.application.dto.request;
 import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
 import com.yd.vibecode.domain.submission.domain.entity.Verdict;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.List;
 
@@ -10,13 +13,19 @@ import java.util.List;
  * FastAPI에서 채점 완료 후 전송하는 요청 DTO
  */
 public record ScoringResultRequest(
+    @NotNull(message = "status는 필수입니다")
     SubmissionStatus status,
+    @NotNull(message = "testCases는 필수입니다")
+    @Valid
     List<TestCaseResult> testCases,
     ScoreData score
 ) {
     public record TestCaseResult(
+        @NotNull(message = "caseIndex는 필수입니다")
         Integer caseIndex,
+        @NotBlank(message = "group은 필수입니다")
         String group,  // SAMPLE, PUBLIC, PRIVATE
+        @NotNull(message = "verdict는 필수입니다")
         Verdict verdict,
         Integer timeMs,
         Integer memKb,

--- a/src/main/java/com/yd/vibecode/domain/submission/application/event/ScoringResultSseEvent.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/event/ScoringResultSseEvent.java
@@ -3,6 +3,7 @@ package com.yd.vibecode.domain.submission.application.event;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.yd.vibecode.domain.submission.domain.entity.RunGroup;
 import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
 import com.yd.vibecode.domain.submission.domain.entity.Verdict;
 
@@ -17,13 +18,20 @@ public record ScoringResultSseEvent(
     Long submissionId,
     SubmissionStatus status,
     List<CaseResultPayload> caseResults,
+    CompletionPayload completion,
     FinalScorePayload finalScore  // nullable (score 없는 경우)
 ) {
     public record CaseResultPayload(
         int caseIndex,
+        RunGroup group,
         Verdict verdict,
         int timeMs,
         int memKb
+    ) {}
+
+    public record CompletionPayload(
+        int runCount,
+        int passedCount
     ) {}
 
     public record FinalScorePayload(

--- a/src/main/java/com/yd/vibecode/domain/submission/application/usecase/ReceiveScoringResultUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/usecase/ReceiveScoringResultUseCase.java
@@ -95,7 +95,12 @@ public class ReceiveScoringResultUseCase {
                 finalScore
         ));
 
-        log.info("Scoring result saved, SSE event published: submissionId={}, status={}",
-                submissionId, request.status());
+        log.info(
+                "Scoring result saved, SSE event published: submissionId={}, status={}, runs={}, scoreSaved={}, sseFinalScore={}",
+                submissionId,
+                request.status(),
+                casePayloads.size(),
+                request.score() != null,
+                finalScore != null);
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/application/usecase/ReceiveScoringResultUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/application/usecase/ReceiveScoringResultUseCase.java
@@ -12,9 +12,13 @@ import com.yd.vibecode.domain.submission.domain.entity.RunGroup;
 import com.yd.vibecode.domain.submission.domain.entity.Score;
 import com.yd.vibecode.domain.submission.domain.entity.Submission;
 import com.yd.vibecode.domain.submission.domain.entity.SubmissionRun;
+import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
+import com.yd.vibecode.domain.submission.domain.entity.Verdict;
 import com.yd.vibecode.domain.submission.domain.repository.ScoreRepository;
 import com.yd.vibecode.domain.submission.domain.repository.SubmissionRunRepository;
 import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,17 +42,21 @@ public class ReceiveScoringResultUseCase {
 
     @Transactional
     public void execute(Long submissionId, ScoringResultRequest request) {
-        // 1. Submission 상태 업데이트
+        validateTestCases(request);
+
         Submission submission = submissionService.findById(submissionId);
         submission.updateStatus(request.status());
 
-        // 2. SubmissionRun 저장
+        submissionRunRepository.deleteBySubmissionId(submissionId);
+
+        int passedCount = 0;
         List<ScoringResultSseEvent.CaseResultPayload> casePayloads = request.testCases().stream()
                 .map(tc -> {
+                    RunGroup group = parseRunGroup(tc.group());
                     SubmissionRun run = SubmissionRun.builder()
                             .submissionId(submissionId)
                             .caseIndex(tc.caseIndex())
-                            .grp(RunGroup.valueOf(tc.group()))
+                            .grp(group)
                             .verdict(tc.verdict())
                             .timeMs(tc.timeMs())
                             .memKb(tc.memKb())
@@ -59,6 +67,7 @@ public class ReceiveScoringResultUseCase {
 
                     return new ScoringResultSseEvent.CaseResultPayload(
                             tc.caseIndex(),
+                            group,
                             tc.verdict(),
                             tc.timeMs() != null ? tc.timeMs() : 0,
                             tc.memKb() != null ? tc.memKb() : 0
@@ -66,34 +75,43 @@ public class ReceiveScoringResultUseCase {
                 })
                 .toList();
 
-        // 3. Score 저장
+        for (ScoringResultSseEvent.CaseResultPayload payload : casePayloads) {
+            if (payload.verdict() == Verdict.AC) {
+                passedCount++;
+            }
+        }
+
         ScoringResultSseEvent.FinalScorePayload finalScore = null;
         if (request.score() != null) {
-            Score score = Score.builder()
-                    .submissionId(submissionId)
-                    .promptScore(request.score().promptScore())
-                    .perfScore(request.score().perfScore())
-                    .correctnessScore(request.score().correctnessScore())
-                    .rubricJson(request.score().rubricJson())
-                    .build();
-            score.calculateTotalScore();
+            ScoringResultRequest.ScoreData scoreData = request.score();
+            Score score = scoreRepository.findBySubmissionId(submissionId)
+                    .orElseGet(() -> Score.builder()
+                            .submissionId(submissionId)
+                            .build());
+            score.updateFrom(
+                    scoreData.promptScore(),
+                    scoreData.perfScore(),
+                    scoreData.correctnessScore(),
+                    scoreData.rubricJson());
             scoreRepository.save(score);
 
             finalScore = new ScoringResultSseEvent.FinalScorePayload(
                     score.getPromptScore(),
                     score.getPerfScore(),
                     score.getCorrectnessScore(),
-                    score.getTotalScore()  // calculateTotalScore() 결과 재사용
-            );
+                    score.getTotalScore());
         }
 
-        // 4. SSE 이벤트 publish (트랜잭션 커밋 후 SseScoringEventListener가 처리)
+        ScoringResultSseEvent.CompletionPayload completion = new ScoringResultSseEvent.CompletionPayload(
+                casePayloads.size(),
+                passedCount);
+
         eventPublisher.publishEvent(new ScoringResultSseEvent(
                 submissionId,
                 request.status(),
                 casePayloads,
-                finalScore
-        ));
+                completion,
+                finalScore));
 
         log.info(
                 "Scoring result saved, SSE event published: submissionId={}, status={}, runs={}, scoreSaved={}, sseFinalScore={}",
@@ -102,5 +120,19 @@ public class ReceiveScoringResultUseCase {
                 casePayloads.size(),
                 request.score() != null,
                 finalScore != null);
+    }
+
+    private static void validateTestCases(ScoringResultRequest request) {
+        if (request.status() == SubmissionStatus.DONE && request.testCases().isEmpty()) {
+            throw new RestApiException(GlobalErrorStatus._BAD_REQUEST);
+        }
+    }
+
+    private static RunGroup parseRunGroup(String group) {
+        try {
+            return RunGroup.valueOf(group.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new RestApiException(GlobalErrorStatus._BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/domain/entity/Score.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/domain/entity/Score.java
@@ -60,4 +60,13 @@ public class Score extends BaseEntity {
     public void calculateTotalScore() {
         this.totalScore = promptScore.add(perfScore).add(correctnessScore);
     }
+
+    public void updateFrom(BigDecimal promptScore, BigDecimal perfScore,
+                           BigDecimal correctnessScore, String rubricJson) {
+        this.promptScore = promptScore != null ? promptScore : BigDecimal.ZERO;
+        this.perfScore = perfScore != null ? perfScore : BigDecimal.ZERO;
+        this.correctnessScore = correctnessScore != null ? correctnessScore : BigDecimal.ZERO;
+        this.rubricJson = rubricJson;
+        calculateTotalScore();
+    }
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/domain/repository/SubmissionRunRepository.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/domain/repository/SubmissionRunRepository.java
@@ -11,4 +11,6 @@ public interface SubmissionRunRepository extends JpaRepository<SubmissionRun, Lo
     List<SubmissionRun> findBySubmissionId(Long submissionId);
     
     List<SubmissionRun> findBySubmissionIdOrderByCaseIndexAsc(Long submissionId);
+
+    void deleteBySubmissionId(Long submissionId);
 }

--- a/src/main/java/com/yd/vibecode/domain/submission/infrastructure/SseEmitterRegistry.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/infrastructure/SseEmitterRegistry.java
@@ -68,7 +68,7 @@ public class SseEmitterRegistry {
     public void send(Long submissionId, String eventName, Object data) {
         CopyOnWriteArrayList<SseEmitter> list = emitters.get(submissionId);
         if (list == null || list.isEmpty()) {
-            log.info("No SSE emitter for submissionId={}, event={} skipped (no /stream subscriber)",
+            log.debug("No SSE emitter for submissionId={}, event={} skipped (no /stream subscriber)",
                     submissionId, eventName);
             return;
         }

--- a/src/main/java/com/yd/vibecode/domain/submission/infrastructure/SseEmitterRegistry.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/infrastructure/SseEmitterRegistry.java
@@ -68,7 +68,8 @@ public class SseEmitterRegistry {
     public void send(Long submissionId, String eventName, Object data) {
         CopyOnWriteArrayList<SseEmitter> list = emitters.get(submissionId);
         if (list == null || list.isEmpty()) {
-            log.debug("No SSE emitter for submissionId={}, client disconnected", submissionId);
+            log.info("No SSE emitter for submissionId={}, event={} skipped (no /stream subscriber)",
+                    submissionId, eventName);
             return;
         }
 

--- a/src/main/java/com/yd/vibecode/domain/submission/infrastructure/SseRetryExecutor.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/infrastructure/SseRetryExecutor.java
@@ -91,13 +91,21 @@ public class SseRetryExecutor {
             for (ScoringResultSseEvent.CaseResultPayload caseResult : event.caseResults()) {
                 sseEmitterRegistry.send(submissionId, "case_result", Map.of(
                         "caseIndex", caseResult.caseIndex(),
+                        "group", caseResult.group(),
                         "verdict", caseResult.verdict(),
                         "timeMs", caseResult.timeMs(),
                         "memKb", caseResult.memKb()
                 ));
             }
 
-            // 2. 최종 점수 전송
+            sseEmitterRegistry.send(submissionId, "scoring_complete", Map.of(
+                    "submissionId", submissionId,
+                    "status", event.status(),
+                    "runCount", event.completion().runCount(),
+                    "passedCount", event.completion().passedCount()
+            ));
+
+            // 3. 최종 점수 전송 (score 있을 때만)
             if (event.finalScore() != null) {
                 sseEmitterRegistry.send(submissionId, "final_score", Map.of(
                         "submissionId", submissionId,
@@ -109,7 +117,7 @@ public class SseRetryExecutor {
                 ));
             }
 
-            // 3. 스트림 종료
+            // 4. 스트림 종료
             sseEmitterRegistry.complete(submissionId);
             log.info("[SSE Outbox] Delivery succeeded: submissionId={}, attempt={}", submissionId, attempt + 1);
 

--- a/src/main/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionStreamController.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/ui/AdminSubmissionStreamController.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
  *
  * GET /api/admin/submissions/{submissionId}/stream
  * - text/event-stream 응답
- * - 이벤트: case_result (테스트 케이스별), final_score (최종 점수)
+ * - 이벤트: case_result, scoring_complete, final_score (선택)
  */
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/yd/vibecode/domain/submission/ui/InternalSubmissionController.java
+++ b/src/main/java/com/yd/vibecode/domain/submission/ui/InternalSubmissionController.java
@@ -17,10 +17,11 @@ import lombok.RequiredArgsConstructor;
 /**
  * Internal API Controller (FastAPI용)
  * - POST /api/internal/submissions/{id}/result: 채점 결과 수신
- * 
- * 주의: 이 API는 내부 네트워크에서만 호출되어야 합니다.
- * 프로덕션에서는 IP 화이트리스트 또는 내부 토큰으로 보호 필요
+ *
+ * @deprecated {@code POST /api/callbacks/ai/submissions/{submissionId}/result} 사용 (permitAll).
+ * 제거 예정.
  */
+@Deprecated(forRemoval = true)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/internal/submissions")
@@ -28,6 +29,7 @@ public class InternalSubmissionController implements InternalSubmissionApi {
 
     private final ReceiveScoringResultUseCase receiveScoringResultUseCase;
 
+    @Deprecated(forRemoval = true)
     @PostMapping("/{id}/result")
     public BaseResponse<Void> receiveScoringResult(
             @PathVariable Long id,

--- a/src/main/java/com/yd/vibecode/global/swagger/AICallbackApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/AICallbackApi.java
@@ -36,7 +36,8 @@ public interface AICallbackApi extends BaseApi {
     @Operation(
             summary = "채점 결과 수신",
             description = "AI Worker가 N9 이후 testCases, score, status를 전송합니다. "
-                    + "submission_runs, scores 저장 및 SSE 발행."
+                    + "submission_runs, scores 저장 및 SSE(case_result, scoring_complete, final_score) 발행. "
+                    + "재호출 시 기존 runs/score를 덮어씁니다."
     )
     @ApiResponse(responseCode = "200", description = "채점 결과 수신 성공")
     @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content)

--- a/src/main/java/com/yd/vibecode/global/swagger/AICallbackApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/AICallbackApi.java
@@ -1,6 +1,7 @@
 package com.yd.vibecode.global.swagger;
 
 import com.yd.vibecode.domain.submission.application.dto.request.AISubmissionStatusRequest;
+import com.yd.vibecode.domain.submission.application.dto.request.ScoringResultRequest;
 import com.yd.vibecode.global.common.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,12 +9,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "AI 콜백", description = "AI 제출 상태 업데이트 수신 API")
+@Tag(name = "AI 콜백", description = "AI Worker 콜백 API (상태 알림 / 채점 결과)")
 public interface AICallbackApi extends BaseApi {
 
     @Operation(
             summary = "제출 상태 업데이트",
-            description = "AI 서버로부터 제출 평가 완료 상태를 수신하여 Submission 상태를 업데이트합니다."
+            description = "AI 서버로부터 제출 상태만 수신합니다 (RUNNING, FAILED 권장). "
+                    + "채점 완료(DONE) 및 testCases/score는 /submissions/{submissionId}/result 로 전달하세요."
     )
     @ApiResponse(
             responseCode = "200",
@@ -30,4 +32,14 @@ public interface AICallbackApi extends BaseApi {
             content = @Content
     )
     BaseResponse<Void> receiveAnalysisResult(AISubmissionStatusRequest request);
+
+    @Operation(
+            summary = "채점 결과 수신",
+            description = "AI Worker가 N9 이후 testCases, score, status를 전송합니다. "
+                    + "submission_runs, scores 저장 및 SSE 발행."
+    )
+    @ApiResponse(responseCode = "200", description = "채점 결과 수신 성공")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content)
+    @ApiResponse(responseCode = "404", description = "제출을 찾을 수 없음", content = @Content)
+    BaseResponse<Void> receiveScoringResult(Long submissionId, ScoringResultRequest request);
 }

--- a/src/main/java/com/yd/vibecode/global/swagger/AdminSubmissionStreamApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/AdminSubmissionStreamApi.java
@@ -16,9 +16,10 @@ public interface AdminSubmissionStreamApi extends BaseApi {
             제출 ID에 대한 채점 결과를 SSE(Server-Sent Events)로 실시간 스트리밍합니다.
             Admin/Master 권한이 필요합니다.
 
-            **이벤트 타입:**
-            - `case_result`: 테스트 케이스별 결과 (caseIndex, verdict, timeMs, memKb)
-            - `final_score`: 최종 점수 (promptScore, perfScore, correctnessScore, total)
+            **이벤트 타입 (순서):**
+            - `case_result`: 테스트 케이스별 결과 (caseIndex, group, verdict, timeMs, memKb)
+            - `scoring_complete`: 채점 종료 (submissionId, status, runCount, passedCount)
+            - `final_score`: 최종 점수 (score 있을 때만, promptScore, perfScore, correctnessScore, total)
 
             **주의:** Swagger UI에서는 SSE를 직접 테스트하기 어렵습니다.
             curl 또는 브라우저 개발자 도구를 사용하세요.

--- a/src/main/java/com/yd/vibecode/global/swagger/SubmissionStreamApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/SubmissionStreamApi.java
@@ -17,7 +17,7 @@ public interface SubmissionStreamApi extends BaseApi {
             description = """
                     제출 ID에 대한 채점 진행 상황을 SSE로 수신합니다. **해당 제출의 소유자(토큰의 user id = submissions.participant_id)**만 연결할 수 있습니다.
 
-                    이벤트는 관리자 스트림과 동일하게 `case_result`, `final_score`만 전달되며, 제출 코드·루브릭 등 민감 필드는 포함하지 않습니다.
+                    이벤트는 관리자 스트림과 동일하게 `case_result`, `scoring_complete`, `final_score`(선택) 순으로 전달되며, 제출 코드·루브릭 등 민감 필드는 포함하지 않습니다.
                     """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "SSE 스트림 연결 성공", content = @Content()),

--- a/src/test/java/com/yd/vibecode/domain/submission/application/usecase/ReceiveScoringResultUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/application/usecase/ReceiveScoringResultUseCaseTest.java
@@ -1,15 +1,19 @@
 package com.yd.vibecode.domain.submission.application.usecase;
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
@@ -24,6 +28,7 @@ import com.yd.vibecode.domain.submission.domain.entity.Verdict;
 import com.yd.vibecode.domain.submission.domain.repository.ScoreRepository;
 import com.yd.vibecode.domain.submission.domain.repository.SubmissionRunRepository;
 import com.yd.vibecode.domain.submission.domain.service.SubmissionService;
+import com.yd.vibecode.global.exception.RestApiException;
 
 @ExtendWith(MockitoExtension.class)
 class ReceiveScoringResultUseCaseTest {
@@ -46,34 +51,127 @@ class ReceiveScoringResultUseCaseTest {
     @Test
     @DisplayName("채점 결과 수신 및 처리 성공 - DB 저장 및 SSE 이벤트 발행 확인")
     void execute_Success() {
-        // given
         Long submissionId = 1L;
         Submission submission = Submission.builder()
                 .status(SubmissionStatus.RUNNING)
                 .build();
 
         ScoringResultRequest.TestCaseResult testCase = new ScoringResultRequest.TestCaseResult(
-            0, "SAMPLE", Verdict.AC, 100, 1024, 0, 0
-        );
+                0, "SAMPLE", Verdict.AC, 100, 1024, 0, 0);
 
         ScoringResultRequest.ScoreData scoreResult = new ScoringResultRequest.ScoreData(
-            new BigDecimal("30.0"), new BigDecimal("30.0"), new BigDecimal("40.0"), "{}"
-        );
+                new BigDecimal("30.0"), new BigDecimal("30.0"), new BigDecimal("40.0"), "{}");
 
         ScoringResultRequest request = new ScoringResultRequest(
-            SubmissionStatus.DONE,
-            List.of(testCase),
-            scoreResult
-        );
+                SubmissionStatus.DONE,
+                List.of(testCase),
+                scoreResult);
 
         given(submissionService.findById(submissionId)).willReturn(submission);
+        given(scoreRepository.findBySubmissionId(submissionId)).willReturn(Optional.empty());
 
-        // when
         receiveScoringResultUseCase.execute(submissionId, request);
 
-        // then
+        verify(submissionRunRepository).deleteBySubmissionId(submissionId);
         verify(submissionRunRepository).save(any(SubmissionRun.class));
         verify(scoreRepository).save(any(Score.class));
         verify(eventPublisher).publishEvent(any(ScoringResultSseEvent.class));
+    }
+
+    @Test
+    @DisplayName("DONE 상태인데 testCases가 비어 있으면 400")
+    void execute_doneWithEmptyTestCases_throwsBadRequest() {
+        Long submissionId = 1L;
+        ScoringResultRequest request = new ScoringResultRequest(
+                SubmissionStatus.DONE,
+                Collections.emptyList(),
+                null);
+
+        assertThatThrownBy(() -> receiveScoringResultUseCase.execute(submissionId, request))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    @DisplayName("잘못된 group 값이면 400")
+    void execute_invalidGroup_throwsBadRequest() {
+        Long submissionId = 1L;
+        Submission submission = Submission.builder().build();
+        ScoringResultRequest.TestCaseResult testCase = new ScoringResultRequest.TestCaseResult(
+                0, "INVALID", Verdict.AC, 100, 1024, 0, 0);
+        ScoringResultRequest request = new ScoringResultRequest(
+                SubmissionStatus.DONE,
+                List.of(testCase),
+                null);
+
+        given(submissionService.findById(submissionId)).willReturn(submission);
+
+        assertThatThrownBy(() -> receiveScoringResultUseCase.execute(submissionId, request))
+                .isInstanceOf(RestApiException.class);
+    }
+
+    @Test
+    @DisplayName("FAILED + 빈 testCases는 허용")
+    void execute_failedWithEmptyTestCases_succeeds() {
+        Long submissionId = 1L;
+        Submission submission = Submission.builder().build();
+        ScoringResultRequest request = new ScoringResultRequest(
+                SubmissionStatus.FAILED,
+                Collections.emptyList(),
+                null);
+
+        given(submissionService.findById(submissionId)).willReturn(submission);
+
+        receiveScoringResultUseCase.execute(submissionId, request);
+
+        verify(submissionRunRepository).deleteBySubmissionId(submissionId);
+        verify(eventPublisher).publishEvent(any(ScoringResultSseEvent.class));
+    }
+
+    @Test
+    @DisplayName("재콜백 시 기존 runs 삭제 후 저장")
+    void execute_replace_deletesBeforeEachSave() {
+        Long submissionId = 1L;
+        Submission submission = Submission.builder().build();
+        ScoringResultRequest.TestCaseResult testCase = new ScoringResultRequest.TestCaseResult(
+                0, "PUBLIC", Verdict.WA, 50, 512, 0, 0);
+        ScoringResultRequest request = new ScoringResultRequest(
+                SubmissionStatus.DONE,
+                List.of(testCase),
+                null);
+
+        given(submissionService.findById(submissionId)).willReturn(submission);
+
+        receiveScoringResultUseCase.execute(submissionId, request);
+        receiveScoringResultUseCase.execute(submissionId, request);
+
+        verify(submissionRunRepository, times(2)).deleteBySubmissionId(submissionId);
+        verify(submissionRunRepository, times(2)).save(any(SubmissionRun.class));
+    }
+
+    @Test
+    @DisplayName("기존 score가 있으면 upsert")
+    void execute_existingScore_updatesInsteadOfDuplicateInsert() {
+        Long submissionId = 1L;
+        Submission submission = Submission.builder().build();
+        Score existing = Score.builder()
+                .submissionId(submissionId)
+                .promptScore(BigDecimal.ZERO)
+                .perfScore(BigDecimal.ZERO)
+                .correctnessScore(BigDecimal.ZERO)
+                .build();
+
+        ScoringResultRequest request = new ScoringResultRequest(
+                SubmissionStatus.DONE,
+                List.of(new ScoringResultRequest.TestCaseResult(
+                        0, "SAMPLE", Verdict.AC, 10, 100, 0, 0)),
+                new ScoringResultRequest.ScoreData(
+                        new BigDecimal("10"), new BigDecimal("20"), new BigDecimal("30"), "{}"));
+
+        given(submissionService.findById(submissionId)).willReturn(submission);
+        given(scoreRepository.findBySubmissionId(submissionId)).willReturn(Optional.of(existing));
+
+        receiveScoringResultUseCase.execute(submissionId, request);
+
+        verify(scoreRepository).save(existing);
     }
 }

--- a/src/test/java/com/yd/vibecode/domain/submission/infrastructure/SseRetryExecutorTest.java
+++ b/src/test/java/com/yd/vibecode/domain/submission/infrastructure/SseRetryExecutorTest.java
@@ -1,0 +1,75 @@
+package com.yd.vibecode.domain.submission.infrastructure;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.yd.vibecode.domain.submission.application.event.ScoringResultSseEvent;
+import com.yd.vibecode.domain.submission.domain.entity.RunGroup;
+import com.yd.vibecode.domain.submission.domain.entity.SubmissionStatus;
+import com.yd.vibecode.domain.submission.domain.entity.Verdict;
+
+@ExtendWith(MockitoExtension.class)
+class SseRetryExecutorTest {
+
+    @InjectMocks
+    private SseRetryExecutor sseRetryExecutor;
+
+    @Mock
+    private SseEmitterRegistry sseEmitterRegistry;
+
+    @Test
+    @DisplayName("score 없을 때 case_result → scoring_complete → complete 순서로 전송")
+    void deliverWithRetry_withoutScore_sendsScoringCompleteBeforeComplete() {
+        Long submissionId = 1L;
+        ScoringResultSseEvent event = new ScoringResultSseEvent(
+                submissionId,
+                SubmissionStatus.DONE,
+                List.of(new ScoringResultSseEvent.CaseResultPayload(
+                        0, RunGroup.SAMPLE, Verdict.AC, 100, 1024)),
+                new ScoringResultSseEvent.CompletionPayload(1, 1),
+                null);
+
+        sseRetryExecutor.deliverWithRetry(event);
+
+        InOrder order = inOrder(sseEmitterRegistry);
+        order.verify(sseEmitterRegistry).send(eq(submissionId), eq("case_result"), any());
+        order.verify(sseEmitterRegistry).send(eq(submissionId), eq("scoring_complete"), any());
+        order.verify(sseEmitterRegistry).complete(submissionId);
+        verify(sseEmitterRegistry, never()).send(eq(submissionId), eq("final_score"), any());
+    }
+
+    @Test
+    @DisplayName("score 있을 때 final_score는 scoring_complete 다음에 전송")
+    void deliverWithRetry_withScore_sendsFinalScoreAfterScoringComplete() {
+        Long submissionId = 2L;
+        ScoringResultSseEvent event = new ScoringResultSseEvent(
+                submissionId,
+                SubmissionStatus.DONE,
+                List.of(new ScoringResultSseEvent.CaseResultPayload(
+                        1, RunGroup.PUBLIC, Verdict.WA, 50, 256)),
+                new ScoringResultSseEvent.CompletionPayload(1, 0),
+                new ScoringResultSseEvent.FinalScorePayload(
+                        BigDecimal.TEN, BigDecimal.TEN, BigDecimal.TEN, new BigDecimal("30")));
+
+        sseRetryExecutor.deliverWithRetry(event);
+
+        InOrder order = inOrder(sseEmitterRegistry);
+        order.verify(sseEmitterRegistry).send(eq(submissionId), eq("case_result"), any());
+        order.verify(sseEmitterRegistry).send(eq(submissionId), eq("scoring_complete"), any());
+        order.verify(sseEmitterRegistry).send(eq(submissionId), eq("final_score"), any());
+        order.verify(sseEmitterRegistry).complete(submissionId);
+    }
+}


### PR DESCRIPTION
## Summary
- AI Worker가 채점 완료 후 `POST /api/callbacks/ai/submissions/{submissionId}/result`로 `testCases`, `score`, `status`를 전달하면 BE가 `submission_runs`·`scores`·`submissions.status`를 저장합니다.
- 기존 `ReceiveScoringResultUseCase`·`ScoringResultRequest`를 재사용해 관리자 API `runs[]`가 비어 있던 문제(#37/#64)를 해소합니다.
- `POST /api/callbacks/ai/analysis`는 진행/실패 상태만 수신하도록 Swagger·주석을 정리했습니다. 채점 완료(`DONE`)와 TC 데이터는 `result`로만 보냅니다.
- `POST /api/internal/submissions/{id}/result`는 `@Deprecated(forRemoval = true)` — AI는 콜백 URL만 사용합니다.

## 변경 사항
| 구분 | 내용 |
|------|------|
| API | `POST /api/callbacks/ai/submissions/{submissionId}/result` (permitAll, JWT 제외) |
| 저장 | `submission_runs`, `scores`, submission status |
| 폐기 예정 | `InternalSubmissionController` internal result |
| 로그 | `[AI Callback]`, 채점 저장 runs 수, SSE 미구독 시 INFO |

## AI 팀 연동 (머지 후)
- URL: `{BE_BASE}/api/callbacks/ai/submissions/{submissionId}/result`
- Body: `ScoringResultRequest` (`status`, `testCases[]`, `score` optional)
- N9 이후 **1회** `result` 호출. DB에 `submission_runs`/`scores` 직접 쓰지 않기 (BE가 SoT)
- 성공 시 `analysis`에 `DONE` 보내지 않기 (선택, `result`만으로 충분)


## Test plan
- [x] `./gradlew test` — `ReceiveScoringResultUseCaseTest` 통과
- [x] 로컬 AI 또는 curl로 `result` POST → DB `submission_runs` 10건(또는 TC 수) 확인
- [x] `GET /api/admin/submissions/{id}` 응답 `runs[]` 비어 있지 않음
- [x] `analysis`만 호출 시 status만 변경, runs 미생성
- [x] (선택) Swagger `/swagger-ui` — AI 콜백 `result` 엔드포인트 노출 확인


## 참고
- 참가자 UI SSE(`/stream`) 구독은 **필수 아님**. 구독 없어도 DB 저장은 정상이며, 관리자 조회가 목표입니다.
- SSE Outbox는 기존과 동일하게 동작하며, 미구독 시 `No SSE emitter … skipped` 로그만 남습니다.