### PR TITLE
v1.2.5

### DIFF
--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/CreateExamUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/CreateExamUseCase.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.yd.vibecode.domain.exam.application.dto.request.CreateExamRequest;
 import com.yd.vibecode.domain.exam.application.dto.response.ExamResponse;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Random;
 
@@ -21,6 +22,7 @@ import com.yd.vibecode.domain.problem.infrastructure.entity.ProblemSetItem;
 import com.yd.vibecode.domain.problem.infrastructure.repository.ProblemSetItemRepository;
 import com.yd.vibecode.domain.problem.infrastructure.repository.ProblemSetRepository;
 import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.ExamErrorStatus;
 import com.yd.vibecode.global.exception.code.status.ProblemErrorStatus;
 import com.yd.vibecode.global.util.CodeGenerator;
 
@@ -38,6 +40,10 @@ public class CreateExamUseCase {
 
     @Transactional
     public ExamResponse execute(Long adminId, CreateExamRequest request) {
+        if (!request.endsAt().isAfter(LocalDateTime.now())) {
+            throw new RestApiException(ExamErrorStatus.EXAM_ENDS_AT_NOT_IN_FUTURE);
+        }
+
         // 1. 시험 생성
         Exam exam = Exam.builder()
             .title(request.title())

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/DeleteAdminByMasterUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/DeleteAdminByMasterUseCase.java
@@ -1,0 +1,33 @@
+package com.yd.vibecode.domain.admin.application.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.service.AdminAccountDeletionService;
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteAdminByMasterUseCase {
+
+    private static final String AUDIT_ACTION = "DELETE_ADMIN_BY_MASTER";
+
+    private final AdminService adminService;
+    private final AdminAccountDeletionService adminAccountDeletionService;
+
+    @Transactional
+    public void execute(Long requesterId, String targetAdminNumber) {
+        Admin requester = adminService.findById(requesterId);
+        if (!requester.isMaster()) {
+            throw new RestApiException(AuthErrorStatus.MASTER_ONLY);
+        }
+
+        Admin target = adminService.findByAdminNumber(targetAdminNumber);
+        adminAccountDeletionService.softDelete(target, requesterId, AUDIT_ACTION);
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/admin/application/usecase/DeleteOwnAdminAccountUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/application/usecase/DeleteOwnAdminAccountUseCase.java
@@ -1,0 +1,35 @@
+package com.yd.vibecode.domain.admin.application.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.yd.vibecode.domain.auth.application.usecase.AdminLogoutUseCase;
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.service.AdminAccountDeletionService;
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.global.util.CookieUtils;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteOwnAdminAccountUseCase {
+
+    private static final String AUDIT_ACTION = "DELETE_OWN_ACCOUNT";
+
+    private final AdminService adminService;
+    private final AdminAccountDeletionService adminAccountDeletionService;
+    private final AdminLogoutUseCase adminLogoutUseCase;
+    private final CookieUtils cookieUtils;
+
+    @Transactional
+    public void execute(Long adminId, String accessToken, HttpServletResponse httpResponse) {
+        Admin admin = adminService.findById(adminId);
+        adminAccountDeletionService.softDelete(admin, adminId, AUDIT_ACTION);
+
+        adminLogoutUseCase.execute(accessToken);
+        cookieUtils.clearAccessTokenCookie(httpResponse);
+        cookieUtils.clearRefreshTokenCookie(httpResponse);
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/admin/ui/AdminAccountController.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/ui/AdminAccountController.java
@@ -1,5 +1,6 @@
 package com.yd.vibecode.domain.admin.ui;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,10 +8,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.yd.vibecode.domain.admin.application.dto.request.ChangeAdminPasswordRequest;
 import com.yd.vibecode.domain.admin.application.usecase.ChangeAdminPasswordUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.DeleteOwnAdminAccountUseCase;
 import com.yd.vibecode.global.swagger.AdminAccountApi;
+import com.yd.vibecode.global.annotation.AccessToken;
 import com.yd.vibecode.global.annotation.CurrentUser;
 import com.yd.vibecode.global.common.BaseResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +25,7 @@ import lombok.RequiredArgsConstructor;
 public class AdminAccountController implements AdminAccountApi {
 
     private final ChangeAdminPasswordUseCase changeAdminPasswordUseCase;
+    private final DeleteOwnAdminAccountUseCase deleteOwnAdminAccountUseCase;
 
     @PatchMapping("/password")
     @Override
@@ -28,6 +34,20 @@ public class AdminAccountController implements AdminAccountApi {
         @Valid @RequestBody ChangeAdminPasswordRequest request
     ) {
         changeAdminPasswordUseCase.execute(Long.parseLong(adminId), request);
+        return BaseResponse.onSuccess();
+    }
+
+    @DeleteMapping
+    @Operation(
+            summary = "본인 관리자 계정 삭제",
+            description = "현재 로그인한 관리자가 자신의 계정을 soft delete 합니다. 마스터 계정은 삭제할 수 없습니다."
+    )
+    public BaseResponse<Void> deleteOwnAccount(
+        @CurrentUser String adminId,
+        @AccessToken String accessToken,
+        HttpServletResponse httpResponse
+    ) {
+        deleteOwnAdminAccountUseCase.execute(Long.parseLong(adminId), accessToken, httpResponse);
         return BaseResponse.onSuccess();
     }
 }

--- a/src/main/java/com/yd/vibecode/domain/admin/ui/AdminNumberController.java
+++ b/src/main/java/com/yd/vibecode/domain/admin/ui/AdminNumberController.java
@@ -1,71 +1,82 @@
-package com.yd.vibecode.domain.admin.ui;
-
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.yd.vibecode.domain.admin.application.dto.request.AdminNumberIssueRequest;
-import com.yd.vibecode.domain.admin.application.dto.request.AdminNumberUpdateRequest;
-import com.yd.vibecode.domain.admin.application.dto.response.AdminListResponse;
-import com.yd.vibecode.domain.admin.application.dto.response.AdminNumberResponse;
-import com.yd.vibecode.domain.admin.application.dto.response.ResetAdminPasswordByMasterResponse;
-import com.yd.vibecode.domain.admin.application.usecase.GetAllAdminsUseCase;
-import com.yd.vibecode.domain.admin.application.usecase.IssueAdminNumberUseCase;
-import com.yd.vibecode.domain.admin.application.usecase.ResetAdminPasswordByMasterUseCase;
-import com.yd.vibecode.domain.admin.application.usecase.UpdateAdminNumberUseCase;
-import com.yd.vibecode.global.annotation.CurrentUser;
-import com.yd.vibecode.global.common.BaseResponse;
-import com.yd.vibecode.global.swagger.AdminNumberApi;
-
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-
-@RestController
-@RequiredArgsConstructor
-@RequestMapping("/api/admin/admin-numbers")
-public class AdminNumberController implements AdminNumberApi {
-
-    private final IssueAdminNumberUseCase issueAdminNumberUseCase;
-    private final UpdateAdminNumberUseCase updateAdminNumberUseCase;
-    private final GetAllAdminsUseCase getAllAdminsUseCase;
-    private final ResetAdminPasswordByMasterUseCase resetAdminPasswordByMasterUseCase;
-
-    @GetMapping("/admins")
-    @Override
-    public BaseResponse<AdminListResponse> getAllAdmins(@CurrentUser String adminId) {
-        AdminListResponse response = getAllAdminsUseCase.execute(Long.parseLong(adminId));
-        return BaseResponse.onSuccess(response);
-    }
-
-    @PostMapping
-    @Override
-    public BaseResponse<AdminNumberResponse> issueAdminNumber(@CurrentUser String adminId,
-                                                              @Valid @RequestBody AdminNumberIssueRequest request) {
-        AdminNumberResponse response = issueAdminNumberUseCase.execute(Long.parseLong(adminId), request);
-        return BaseResponse.onSuccess(response);
-    }
-
-    @PatchMapping("/{adminNumber}/password/reset")
-    @Override
-    public BaseResponse<ResetAdminPasswordByMasterResponse> resetAdminPasswordByMaster(
-            @CurrentUser String adminId,
-            @PathVariable String adminNumber) {
-        ResetAdminPasswordByMasterResponse response =
-                resetAdminPasswordByMasterUseCase.execute(Long.parseLong(adminId), adminNumber);
-        return BaseResponse.onSuccess(response);
-    }
-
-    @PatchMapping("/{adminNumber}")
-    @Override
-    public BaseResponse<AdminNumberResponse> updateAdminNumber(@CurrentUser String adminId,
-                                                               @PathVariable String adminNumber,
-                                                               @Valid @RequestBody AdminNumberUpdateRequest request) {
-        AdminNumberResponse response = updateAdminNumberUseCase.execute(Long.parseLong(adminId), adminNumber, request);
-        return BaseResponse.onSuccess(response);
-    }
-}
-
+package com.yd.vibecode.domain.admin.ui;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.yd.vibecode.domain.admin.application.dto.request.AdminNumberIssueRequest;
+import com.yd.vibecode.domain.admin.application.dto.request.AdminNumberUpdateRequest;
+import com.yd.vibecode.domain.admin.application.dto.response.AdminListResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.AdminNumberResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.ResetAdminPasswordByMasterResponse;
+import com.yd.vibecode.domain.admin.application.usecase.DeleteAdminByMasterUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.GetAllAdminsUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.IssueAdminNumberUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.ResetAdminPasswordByMasterUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.UpdateAdminNumberUseCase;
+import com.yd.vibecode.global.annotation.CurrentUser;
+import com.yd.vibecode.global.common.BaseResponse;
+import com.yd.vibecode.global.swagger.AdminNumberApi;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/admin-numbers")
+public class AdminNumberController implements AdminNumberApi {
+
+    private final IssueAdminNumberUseCase issueAdminNumberUseCase;
+    private final UpdateAdminNumberUseCase updateAdminNumberUseCase;
+    private final GetAllAdminsUseCase getAllAdminsUseCase;
+    private final ResetAdminPasswordByMasterUseCase resetAdminPasswordByMasterUseCase;
+    private final DeleteAdminByMasterUseCase deleteAdminByMasterUseCase;
+
+    @GetMapping("/admins")
+    @Override
+    public BaseResponse<AdminListResponse> getAllAdmins(@CurrentUser String adminId) {
+        AdminListResponse response = getAllAdminsUseCase.execute(Long.parseLong(adminId));
+        return BaseResponse.onSuccess(response);
+    }
+
+    @PostMapping
+    @Override
+    public BaseResponse<AdminNumberResponse> issueAdminNumber(@CurrentUser String adminId,
+                                                              @Valid @RequestBody AdminNumberIssueRequest request) {
+        AdminNumberResponse response = issueAdminNumberUseCase.execute(Long.parseLong(adminId), request);
+        return BaseResponse.onSuccess(response);
+    }
+
+    @PatchMapping("/{adminNumber}/password/reset")
+    @Override
+    public BaseResponse<ResetAdminPasswordByMasterResponse> resetAdminPasswordByMaster(
+            @CurrentUser String adminId,
+            @PathVariable String adminNumber) {
+        ResetAdminPasswordByMasterResponse response =
+                resetAdminPasswordByMasterUseCase.execute(Long.parseLong(adminId), adminNumber);
+        return BaseResponse.onSuccess(response);
+    }
+
+    @PatchMapping("/{adminNumber}")
+    @Override
+    public BaseResponse<AdminNumberResponse> updateAdminNumber(@CurrentUser String adminId,
+                                                               @PathVariable String adminNumber,
+                                                               @Valid @RequestBody AdminNumberUpdateRequest request) {
+        AdminNumberResponse response = updateAdminNumberUseCase.execute(Long.parseLong(adminId), adminNumber, request);
+        return BaseResponse.onSuccess(response);
+    }
+
+    @DeleteMapping("/{adminNumber}")
+    @Override
+    public BaseResponse<Void> deleteAdminByMaster(@CurrentUser String adminId,
+                                                  @PathVariable String adminNumber) {
+        deleteAdminByMasterUseCase.execute(Long.parseLong(adminId), adminNumber);
+        return BaseResponse.onSuccess();
+    }
+}
+

--- a/src/main/java/com/yd/vibecode/domain/auth/application/usecase/AdminLoginUseCase.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/application/usecase/AdminLoginUseCase.java
@@ -30,8 +30,8 @@ public class AdminLoginUseCase {
             admin = adminService.findByAdminNumber(request.identifier());
         }
 
-        // 2. 계정 활성 상태 확인
-        if (!admin.getIsActive()) {
+        // 2. 삭제·비활성 계정 로그인 차단
+        if (admin.isDeleted() || !admin.getIsActive()) {
             throw new RestApiException(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE);
         }
 

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminAccessAuthValidator.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminAccessAuthValidator.java
@@ -1,0 +1,30 @@
+package com.yd.vibecode.domain.auth.domain.service;
+
+import org.springframework.stereotype.Component;
+
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.repository.AdminRepository;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * JWT 인증 파이프라인용 관리자 access token 활성 상태 검증.
+ * PasswordEncoder 등 SecurityConfig Bean에 의존하지 않도록 분리한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class AdminAccessAuthValidator {
+
+    private final AdminRepository adminRepository;
+
+    public void validateActiveForAuthentication(Long adminId) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new RestApiException(GlobalErrorStatus._NOT_FOUND));
+        if (admin.isDeleted() || !Boolean.TRUE.equals(admin.getIsActive())) {
+            throw new RestApiException(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE);
+        }
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminAccountDeletionService.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminAccountDeletionService.java
@@ -1,0 +1,53 @@
+package com.yd.vibecode.domain.auth.domain.service;
+
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.yd.vibecode.domain.admin.domain.service.AdminAuditLogService;
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.entity.AdminNumber;
+import com.yd.vibecode.domain.auth.domain.repository.AdminNumberRepository;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAccountDeletionService {
+
+    private final RefreshTokenService refreshTokenService;
+    private final AdminNumberRepository adminNumberRepository;
+    private final AdminAuditLogService adminAuditLogService;
+
+    @Transactional
+    public void softDelete(Admin admin, Long actorAdminId, String auditAction) {
+        if (admin.isDeleted()) {
+            throw new RestApiException(GlobalErrorStatus._NOT_FOUND);
+        }
+        if (admin.isMaster()) {
+            throw new RestApiException(AuthErrorStatus.MASTER_ACCOUNT_CANNOT_BE_DEACTIVATED);
+        }
+
+        admin.delete();
+        admin.updateActive(false);
+        refreshTokenService.deleteRefreshToken(admin.getId().toString());
+
+        adminNumberRepository.findByAdminNumber(admin.getAdminNumber())
+                .ifPresent(this::deactivateAdminNumber);
+
+        if (actorAdminId != null && auditAction != null) {
+            adminAuditLogService.log(actorAdminId, auditAction, Map.of(
+                    "targetAdminId", admin.getId(),
+                    "targetAdminNumber", admin.getAdminNumber()
+            ));
+        }
+    }
+
+    private void deactivateAdminNumber(AdminNumber adminNumber) {
+        adminNumber.update(adminNumber.getLabel(), false, adminNumber.getExpiresAt());
+    }
+}

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminService.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminService.java
@@ -43,16 +43,6 @@ public class AdminService {
                 .orElseThrow(() -> new RestApiException(GlobalErrorStatus._NOT_FOUND));
     }
 
-    /**
-     * access token 인증 시 삭제·비활성 관리자의 보호 API 접근을 차단한다.
-     */
-    public void validateActiveForAuthentication(Long adminId) {
-        Admin admin = findById(adminId);
-        if (admin.isDeleted() || !Boolean.TRUE.equals(admin.getIsActive())) {
-            throw new RestApiException(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE);
-        }
-    }
-
     public String encodePassword(String password) {
         return passwordEncoder.encode(password);
     }

--- a/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminService.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/domain/service/AdminService.java
@@ -43,6 +43,16 @@ public class AdminService {
                 .orElseThrow(() -> new RestApiException(GlobalErrorStatus._NOT_FOUND));
     }
 
+    /**
+     * access token 인증 시 삭제·비활성 관리자의 보호 API 접근을 차단한다.
+     */
+    public void validateActiveForAuthentication(Long adminId) {
+        Admin admin = findById(adminId);
+        if (admin.isDeleted() || !Boolean.TRUE.equals(admin.getIsActive())) {
+            throw new RestApiException(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE);
+        }
+    }
+
     public String encodePassword(String password) {
         return passwordEncoder.encode(password);
     }

--- a/src/main/java/com/yd/vibecode/domain/auth/ui/AuthController.java
+++ b/src/main/java/com/yd/vibecode/domain/auth/ui/AuthController.java
@@ -1,6 +1,7 @@
 package com.yd.vibecode.domain.auth.ui;
 
 import java.time.Duration;
+import java.util.Optional;
 
 import com.yd.vibecode.domain.auth.application.dto.request.AdminLoginRequest;
 import com.yd.vibecode.domain.auth.application.dto.request.AdminSignupRequest;
@@ -99,25 +100,30 @@ public class AuthController implements AuthApi {
     public BaseResponse<Void> adminReissue(HttpServletRequest request, HttpServletResponse httpResponse) {
         String refreshToken = cookieUtils.getRefreshTokenFromRequest(request);
         if (refreshToken == null) {
-            throw new RestApiException(AuthErrorStatus.EMPTY_JWT);
+            failAdminReissue(httpResponse, AuthErrorStatus.INVALID_REFRESH_TOKEN);
         }
         if (!tokenProvider.validateToken(refreshToken)) {
-            throw new RestApiException(AuthErrorStatus.EXPIRED_REFRESH_TOKEN);
+            failAdminReissue(httpResponse, AuthErrorStatus.EXPIRED_REFRESH_TOKEN);
         }
 
-        String adminId = tokenProvider.getId(refreshToken)
-                .orElseThrow(() -> new RestApiException(AuthErrorStatus.INVALID_REFRESH_TOKEN));
+        String adminId = tokenProvider.getId(refreshToken).orElse(null);
+        if (adminId == null) {
+            failAdminReissue(httpResponse, AuthErrorStatus.INVALID_REFRESH_TOKEN);
+        }
 
         if (!refreshTokenService.isExist(refreshToken, adminId)) {
-            throw new RestApiException(AuthErrorStatus.INVALID_REFRESH_TOKEN);
+            failAdminReissue(httpResponse, AuthErrorStatus.INVALID_REFRESH_TOKEN);
         }
 
         // 토큰 로테이션: 기존 refresh token 삭제 후 신규 발급
         refreshTokenService.deleteRefreshToken(adminId);
         String newAccessToken = tokenProvider.createAccessToken(adminId, "ADMIN");
         String newRefreshToken = tokenProvider.createRefreshToken(adminId);
-        Duration remaining = tokenProvider.getRemainingDuration(refreshToken)
-                .orElseThrow(() -> new RestApiException(AuthErrorStatus.EXPIRED_REFRESH_TOKEN));
+        Optional<Duration> remainingOptional = tokenProvider.getRemainingDuration(refreshToken);
+        if (remainingOptional.isEmpty()) {
+            failAdminReissue(httpResponse, AuthErrorStatus.EXPIRED_REFRESH_TOKEN);
+        }
+        Duration remaining = remainingOptional.get();
         refreshTokenService.saveRefreshToken(adminId, newRefreshToken, remaining);
 
         int accessMaxAge = Math.toIntExact(jwtProperties.getAccessTokenExpirationPeriodDay() / 1000);
@@ -126,6 +132,12 @@ public class AuthController implements AuthApi {
         cookieUtils.setRefreshTokenCookie(httpResponse, newRefreshToken, refreshMaxAge);
 
         return BaseResponse.onSuccess();
+    }
+
+    private void failAdminReissue(HttpServletResponse httpResponse, AuthErrorStatus status) {
+        cookieUtils.clearAccessTokenCookie(httpResponse);
+        cookieUtils.clearRefreshTokenCookie(httpResponse);
+        throw new RestApiException(status);
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/yd/vibecode/domain/exam/application/dto/request/CreateExamRequest.java
+++ b/src/main/java/com/yd/vibecode/domain/exam/application/dto/request/CreateExamRequest.java
@@ -2,8 +2,11 @@ package com.yd.vibecode.domain.exam.application.dto.request;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -12,11 +15,14 @@ public record CreateExamRequest(
     String title,
     
     @NotNull(message = "시작 시각은 필수입니다")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @Schema(example = "2025-12-02T10:00:00", type = "string")
     LocalDateTime startsAt,
     
     @NotNull(message = "종료 시각은 필수입니다")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @Schema(example = "2025-12-02T12:00:00", type = "string")
+    @FutureOrPresent(message = "만료일은 현재 이후여야 합니다.")
     LocalDateTime endsAt
 ) {
 }

--- a/src/main/java/com/yd/vibecode/global/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/yd/vibecode/global/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.yd.vibecode.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/yd/vibecode/global/exception/code/status/ExamErrorStatus.java
+++ b/src/main/java/com/yd/vibecode/global/exception/code/status/ExamErrorStatus.java
@@ -19,7 +19,8 @@ public enum ExamErrorStatus implements BaseCodeInterface {
     EXAM_ALREADY_ENDED(HttpStatus.BAD_REQUEST, "EXAM005", "이미 종료된 시험입니다."),
     EXAM_NOT_STARTED(HttpStatus.BAD_REQUEST, "EXAM006", "시험이 아직 시작되지 않았습니다."),
     PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXAM007", "시험 참가자를 찾을 수 없습니다."),
-    NO_ACTIVE_SESSION(HttpStatus.NOT_FOUND, "EXAM008", "현재 활성화된 시험 세션이 없습니다.")
+    NO_ACTIVE_SESSION(HttpStatus.NOT_FOUND, "EXAM008", "현재 활성화된 시험 세션이 없습니다."),
+    EXAM_ENDS_AT_NOT_IN_FUTURE(HttpStatus.BAD_REQUEST, "EXAM009", "만료일은 현재 이후여야 합니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/yd/vibecode/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/yd/vibecode/global/security/JwtAuthenticationFilter.java
@@ -11,7 +11,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.pattern.PathPatternParser;
 
-import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.domain.auth.domain.service.AdminAccessAuthValidator;
 import com.yd.vibecode.domain.auth.domain.service.RefreshTokenService;
 import com.yd.vibecode.domain.auth.domain.service.TokenWhitelistService;
 import com.yd.vibecode.global.exception.RestApiException;
@@ -33,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final ExcludeAuthPathProperties excludeAuthPathProperties;
     private final RefreshTokenService refreshTokenService;
     private final TokenWhitelistService tokenWhitelistService;
-    private final AdminService adminService;
+    private final AdminAccessAuthValidator adminAccessAuthValidator;
 
     private final PathPatternParser pathPatternParser = new PathPatternParser();
 
@@ -117,7 +117,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String adminId = tokenProvider.getId(token)
                 .orElseThrow(() -> new RestApiException(INVALID_ACCESS_TOKEN));
         try {
-            adminService.validateActiveForAuthentication(Long.parseLong(adminId));
+            adminAccessAuthValidator.validateActiveForAuthentication(Long.parseLong(adminId));
         } catch (NumberFormatException e) {
             throw new RestApiException(INVALID_ACCESS_TOKEN);
         }

--- a/src/main/java/com/yd/vibecode/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/yd/vibecode/global/security/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.pattern.PathPatternParser;
 
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
 import com.yd.vibecode.domain.auth.domain.service.RefreshTokenService;
 import com.yd.vibecode.domain.auth.domain.service.TokenWhitelistService;
 import com.yd.vibecode.global.exception.RestApiException;
@@ -32,6 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final ExcludeAuthPathProperties excludeAuthPathProperties;
     private final RefreshTokenService refreshTokenService;
     private final TokenWhitelistService tokenWhitelistService;
+    private final AdminService adminService;
 
     private final PathPatternParser pathPatternParser = new PathPatternParser();
 
@@ -99,7 +101,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void setAuthentication(String token) {
+        tokenProvider.getRole(token)
+                .filter(this::isAdminRole)
+                .ifPresent(role -> validateAdminAccountActive(token));
+
         Authentication authentication = tokenProvider.getAuthentication(token);
         SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private boolean isAdminRole(String role) {
+        return "ADMIN".equals(role) || "MASTER".equals(role);
+    }
+
+    private void validateAdminAccountActive(String token) {
+        String adminId = tokenProvider.getId(token)
+                .orElseThrow(() -> new RestApiException(INVALID_ACCESS_TOKEN));
+        try {
+            adminService.validateActiveForAuthentication(Long.parseLong(adminId));
+        } catch (NumberFormatException e) {
+            throw new RestApiException(INVALID_ACCESS_TOKEN);
+        }
     }
 }

--- a/src/main/java/com/yd/vibecode/global/security/SecurityConfig.java
+++ b/src/main/java/com/yd/vibecode/global/security/SecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
 import com.yd.vibecode.domain.auth.domain.service.RefreshTokenService;
 import com.yd.vibecode.domain.auth.domain.service.TokenWhitelistService;
 import com.yd.vibecode.global.config.properties.CorsProperties;
@@ -39,6 +40,7 @@ public class SecurityConfig {
 	private final ExcludeAuthPathProperties excludeAuthPathProperties;
 	private final RefreshTokenService refreshTokenService;
 	private final TokenWhitelistService tokenWhitelistService;
+	private final AdminService adminService;
 	private final CorsProperties corsProperties;
 
 	@Bean
@@ -117,7 +119,13 @@ public class SecurityConfig {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(tokenProvider, excludeAuthPathProperties, refreshTokenService, tokenWhitelistService);
+        return new JwtAuthenticationFilter(
+                tokenProvider,
+                excludeAuthPathProperties,
+                refreshTokenService,
+                tokenWhitelistService,
+                adminService
+        );
     }
     
     @Bean

--- a/src/main/java/com/yd/vibecode/global/security/SecurityConfig.java
+++ b/src/main/java/com/yd/vibecode/global/security/SecurityConfig.java
@@ -11,7 +11,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -19,7 +18,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.domain.auth.domain.service.AdminAccessAuthValidator;
 import com.yd.vibecode.domain.auth.domain.service.RefreshTokenService;
 import com.yd.vibecode.domain.auth.domain.service.TokenWhitelistService;
 import com.yd.vibecode.global.config.properties.CorsProperties;
@@ -40,7 +39,7 @@ public class SecurityConfig {
 	private final ExcludeAuthPathProperties excludeAuthPathProperties;
 	private final RefreshTokenService refreshTokenService;
 	private final TokenWhitelistService tokenWhitelistService;
-	private final AdminService adminService;
+	private final AdminAccessAuthValidator adminAccessAuthValidator;
 	private final CorsProperties corsProperties;
 
 	@Bean
@@ -124,13 +123,8 @@ public class SecurityConfig {
                 excludeAuthPathProperties,
                 refreshTokenService,
                 tokenWhitelistService,
-                adminService
+                adminAccessAuthValidator
         );
-    }
-    
-    @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder() {
-        return new BCryptPasswordEncoder();
     }
 
     private void writeUnauthorizedResponse(HttpServletResponse response) throws IOException {

--- a/src/main/java/com/yd/vibecode/global/swagger/AdminNumberApi.java
+++ b/src/main/java/com/yd/vibecode/global/swagger/AdminNumberApi.java
@@ -40,4 +40,12 @@ public interface AdminNumberApi extends BaseApi {
             @Parameter(hidden = true) String adminId,
             String adminNumber,
             AdminNumberUpdateRequest request);
+
+    @Operation(
+            summary = "관리자 계정 삭제 (MASTER)",
+            description = "MASTER가 다른 관리자 계정을 soft delete 합니다. 마스터 계정은 삭제할 수 없습니다."
+    )
+    BaseResponse<Void> deleteAdminByMaster(
+            @Parameter(hidden = true) String adminId,
+            String adminNumber);
 }

--- a/src/test/java/com/yd/vibecode/domain/admin/application/usecase/CreateExamUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/application/usecase/CreateExamUseCaseTest.java
@@ -1,0 +1,81 @@
+package com.yd.vibecode.domain.admin.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.yd.vibecode.domain.auth.domain.repository.EntryCodeRepository;
+import com.yd.vibecode.domain.exam.application.dto.request.CreateExamRequest;
+import com.yd.vibecode.domain.exam.domain.repository.ExamRepository;
+import com.yd.vibecode.domain.problem.domain.repository.ProblemRepository;
+import com.yd.vibecode.domain.problem.infrastructure.repository.ProblemSetItemRepository;
+import com.yd.vibecode.domain.problem.infrastructure.repository.ProblemSetRepository;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.ExamErrorStatus;
+
+@ExtendWith(MockitoExtension.class)
+class CreateExamUseCaseTest {
+
+    @InjectMocks
+    private CreateExamUseCase createExamUseCase;
+
+    @Mock
+    private ExamRepository examRepository;
+
+    @Mock
+    private ProblemRepository problemRepository;
+
+    @Mock
+    private ProblemSetRepository problemSetRepository;
+
+    @Mock
+    private ProblemSetItemRepository problemSetItemRepository;
+
+    @Mock
+    private EntryCodeRepository entryCodeRepository;
+
+    @Test
+    @DisplayName("종료 시각이 과거이면 시험 생성 실패 (DB 저장 없음)")
+    void execute_pastEndsAt_throwsBeforeSave() {
+        CreateExamRequest request = new CreateExamRequest(
+            "테스트 시험",
+            LocalDateTime.now().plusHours(1),
+            LocalDateTime.now().minusHours(1)
+        );
+
+        assertThatThrownBy(() -> createExamUseCase.execute(1L, request))
+            .isInstanceOf(RestApiException.class)
+            .satisfies(ex -> assertThat(((RestApiException) ex).getErrorCode().getMessage())
+                .contains("만료일은 현재 이후여야 합니다."));
+
+        verify(examRepository, never()).save(any());
+        verify(problemRepository, never()).findByStatus(any());
+    }
+
+    @Test
+    @DisplayName("종료 시각이 현재 이전이면 EXAM009 오류 코드 반환")
+    void execute_endsAtNotInFuture_returnsExam009() {
+        CreateExamRequest request = new CreateExamRequest(
+            "테스트 시험",
+            LocalDateTime.now().minusHours(1),
+            LocalDateTime.now().minusMinutes(1)
+        );
+
+        assertThatThrownBy(() -> createExamUseCase.execute(1L, request))
+            .isInstanceOf(RestApiException.class)
+            .extracting(ex -> ((RestApiException) ex).getErrorCode().getCode())
+            .isEqualTo(ExamErrorStatus.EXAM_ENDS_AT_NOT_IN_FUTURE.getCode().getCode());
+
+        verify(examRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/admin/application/usecase/DeleteAdminByMasterUseCaseTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/application/usecase/DeleteAdminByMasterUseCaseTest.java
@@ -1,0 +1,68 @@
+package com.yd.vibecode.domain.admin.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.entity.AdminRole;
+import com.yd.vibecode.domain.auth.domain.service.AdminAccountDeletionService;
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteAdminByMasterUseCaseTest {
+
+    @InjectMocks
+    private DeleteAdminByMasterUseCase deleteAdminByMasterUseCase;
+
+    @Mock
+    private AdminService adminService;
+
+    @Mock
+    private AdminAccountDeletionService adminAccountDeletionService;
+
+    @Test
+    @DisplayName("MASTER가 일반 관리자 계정을 삭제할 수 있다")
+    void execute_success() {
+        Long requesterId = 1L;
+        String targetAdminNumber = "ADM-123456";
+
+        Admin requester = Admin.builder().role(AdminRole.MASTER).build();
+        Admin target = Admin.builder().adminNumber(targetAdminNumber).role(AdminRole.ADMIN).build();
+
+        given(adminService.findById(requesterId)).willReturn(requester);
+        given(adminService.findByAdminNumber(targetAdminNumber)).willReturn(target);
+
+        deleteAdminByMasterUseCase.execute(requesterId, targetAdminNumber);
+
+        verify(adminAccountDeletionService).softDelete(
+                eq(target),
+                eq(requesterId),
+                eq("DELETE_ADMIN_BY_MASTER")
+        );
+    }
+
+    @Test
+    @DisplayName("MASTER가 아니면 삭제할 수 없다")
+    void execute_not_master_throws() {
+        Long requesterId = 2L;
+        Admin requester = Admin.builder().role(AdminRole.ADMIN).build();
+
+        given(adminService.findById(requesterId)).willReturn(requester);
+
+        assertThatThrownBy(() -> deleteAdminByMasterUseCase.execute(requesterId, "ADM-123456"))
+                .isInstanceOf(RestApiException.class)
+                .extracting(ex -> ((RestApiException) ex).getErrorCode().getCode())
+                .isEqualTo(AuthErrorStatus.MASTER_ONLY.getCode().getCode());
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/admin/ui/AdminAccountControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/ui/AdminAccountControllerTest.java
@@ -4,9 +4,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +25,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.yd.vibecode.domain.admin.application.usecase.ChangeAdminPasswordUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.DeleteOwnAdminAccountUseCase;
 import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
 import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
 import com.yd.vibecode.global.security.SecurityConfig;
@@ -32,11 +38,17 @@ import com.yd.vibecode.global.security.TokenProvider;
 )
 class AdminAccountControllerTest {
 
+    private static final String ACCESS_TOKEN = "access-token";
+    private static final Long CURRENT_USER_ID = 1L;
+
     @Autowired
     private MockMvc mockMvc;
 
     @MockBean
     private ChangeAdminPasswordUseCase changeAdminPasswordUseCase;
+
+    @MockBean
+    private DeleteOwnAdminAccountUseCase deleteOwnAdminAccountUseCase;
 
     @MockBean
     private JwtBlacklistInterceptor jwtBlacklistInterceptor;
@@ -46,6 +58,18 @@ class AdminAccountControllerTest {
 
     @MockBean
     private TokenProvider tokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        given(jwtBlacklistInterceptor.preHandle(
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class),
+                any()
+        )).willReturn(true);
+        given(tokenProvider.getToken(any(HttpServletRequest.class))).willReturn(Optional.of(ACCESS_TOKEN));
+        given(tokenProvider.isAccessToken(ACCESS_TOKEN)).willReturn(true);
+        given(tokenProvider.getId(ACCESS_TOKEN)).willReturn(Optional.of(String.valueOf(CURRENT_USER_ID)));
+    }
 
     @Test
     @DisplayName("관리자 비밀번호 변경 성공")
@@ -65,5 +89,16 @@ class AdminAccountControllerTest {
                 .content(requestBody))
             .andExpect(status().isOk());
 
+    }
+
+    @Test
+    @DisplayName("관리자 본인 계정 삭제 성공")
+    @WithMockUser(roles = "ADMIN")
+    void deleteOwnAccount_success() throws Exception {
+        mockMvc.perform(delete("/api/admin/account")
+                .header("Authorization", "Bearer " + ACCESS_TOKEN))
+            .andExpect(status().isOk());
+
+        verify(deleteOwnAdminAccountUseCase).execute(eq(CURRENT_USER_ID), eq(ACCESS_TOKEN), any());
     }
 }

--- a/src/test/java/com/yd/vibecode/domain/admin/ui/AdminNumberControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/admin/ui/AdminNumberControllerTest.java
@@ -1,180 +1,198 @@
-package com.yd.vibecode.domain.admin.ui;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MockMvc;
-
-import com.yd.vibecode.domain.admin.application.dto.response.AdminListResponse;
-import com.yd.vibecode.domain.admin.application.dto.response.AdminNumberResponse;
-import com.yd.vibecode.domain.admin.application.dto.response.ResetAdminPasswordByMasterResponse;
-import com.yd.vibecode.domain.admin.application.usecase.GetAllAdminsUseCase;
-import com.yd.vibecode.domain.admin.application.usecase.IssueAdminNumberUseCase;
-import com.yd.vibecode.domain.admin.application.usecase.ResetAdminPasswordByMasterUseCase;
-import com.yd.vibecode.domain.admin.application.usecase.UpdateAdminNumberUseCase;
-import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
-import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
-import com.yd.vibecode.global.security.SecurityConfig;
-import com.yd.vibecode.global.security.TokenProvider;
-
-@WebMvcTest(
-    controllers = AdminNumberController.class,
-    excludeAutoConfiguration = SecurityAutoConfiguration.class,
-    excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
-)
-class AdminNumberControllerTest {
-
-    private static final String ACCESS_TOKEN = "access-token";
-    /** JWT @CurrentUser로 전달되는 요청자(MASTER) ID */
-    private static final Long CURRENT_USER_ID = 1L;
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private IssueAdminNumberUseCase issueAdminNumberUseCase;
-
-    @MockBean
-    private UpdateAdminNumberUseCase updateAdminNumberUseCase;
-
-    @MockBean
-    private GetAllAdminsUseCase getAllAdminsUseCase;
-
-    @MockBean
-    private ResetAdminPasswordByMasterUseCase resetAdminPasswordByMasterUseCase;
-
-    @MockBean
-    private JwtBlacklistInterceptor jwtBlacklistInterceptor;
-
-    @MockBean
-    private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
-
-    @MockBean
-    private TokenProvider tokenProvider;
-
-    @BeforeEach
-    void setUp() throws Exception {
-        given(jwtBlacklistInterceptor.preHandle(
-                any(HttpServletRequest.class),
-                any(HttpServletResponse.class),
-                any()
-        )).willReturn(true);
-        given(excludeBlacklistPathProperties.getExcludeAuthPaths()).willReturn(Collections.emptyList());
-        given(tokenProvider.getToken(any(HttpServletRequest.class))).willReturn(Optional.of(ACCESS_TOKEN));
-        given(tokenProvider.isAccessToken(ACCESS_TOKEN)).willReturn(true);
-        given(tokenProvider.getId(ACCESS_TOKEN)).willReturn(Optional.of(String.valueOf(CURRENT_USER_ID)));
-    }
-
-    @Test
-    @DisplayName("MASTER - 모든 관리자 조회 성공")
-    @WithMockUser(roles = "MASTER")
-    void master_getAllAdmins_success() throws Exception {
-        AdminListResponse mockResponse = new AdminListResponse(List.of());
-        given(getAllAdminsUseCase.execute(eq(CURRENT_USER_ID))).willReturn(mockResponse);
-
-        mockMvc.perform(get("/api/admin/admin-numbers/admins")
-                .header("Authorization", "Bearer " + ACCESS_TOKEN))
-            .andExpect(status().isOk());
-
-        verify(getAllAdminsUseCase).execute(eq(CURRENT_USER_ID));
-    }
-
-    @Test
-    @DisplayName("MASTER - 관리자 번호 발급 성공")
-    @WithMockUser(roles = "MASTER")
-    void master_issueAdminNumber_success() throws Exception {
-        String requestBody = """
-            {
-                "label": "Test Admin",
-                "expiresAt": "2099-12-31T23:59:59"
-            }
-            """;
-
-        AdminNumberResponse mockResponse = new AdminNumberResponse(
-            "ADM-123456", "Test Admin", true, 1L, null,
-            LocalDateTime.parse("2099-12-31T23:59:59"), null, LocalDateTime.now()
-        );
-
-        given(issueAdminNumberUseCase.execute(eq(CURRENT_USER_ID), any())).willReturn(mockResponse);
-
-        mockMvc.perform(post("/api/admin/admin-numbers")
-                .header("Authorization", "Bearer " + ACCESS_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody))
-            .andExpect(status().isOk());
-
-        verify(issueAdminNumberUseCase).execute(eq(CURRENT_USER_ID), any());
-    }
-
-    @Test
-    @DisplayName("MASTER - 관리자 번호 수정 성공")
-    @WithMockUser(roles = "MASTER")
-    void master_updateAdminNumber_success() throws Exception {
-        String adminNumber = "ADM-123456";
-        String requestBody = """
-            {
-                "label": "Updated Admin",
-                "active": false
-            }
-            """;
-
-        AdminNumberResponse mockResponse = new AdminNumberResponse(
-            adminNumber, "Updated Admin", false, 1L, null, null, null, LocalDateTime.now()
-        );
-
-        given(updateAdminNumberUseCase.execute(eq(CURRENT_USER_ID), eq(adminNumber), any()))
-            .willReturn(mockResponse);
-
-        mockMvc.perform(patch("/api/admin/admin-numbers/" + adminNumber)
-                .header("Authorization", "Bearer " + ACCESS_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody))
-            .andExpect(status().isOk());
-
-        verify(updateAdminNumberUseCase).execute(eq(CURRENT_USER_ID), eq(adminNumber), any());
-    }
-
-    @Test
-    @DisplayName("MASTER - 타 관리자 임시 비밀번호 재설정 성공")
-    @WithMockUser(roles = "MASTER")
-    void master_resetAdminPasswordByMaster_success() throws Exception {
-        String adminNumber = "ADM-123456";
-
-        given(resetAdminPasswordByMasterUseCase.execute(eq(CURRENT_USER_ID), eq(adminNumber)))
-                .willReturn(new ResetAdminPasswordByMasterResponse("TempPass1!xYz"));
-
-        mockMvc.perform(patch("/api/admin/admin-numbers/" + adminNumber + "/password/reset")
-                .header("Authorization", "Bearer " + ACCESS_TOKEN))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.result.temporaryPassword").value("TempPass1!xYz"));
-
-        verify(resetAdminPasswordByMasterUseCase).execute(eq(CURRENT_USER_ID), eq(adminNumber));
-        verify(updateAdminNumberUseCase, never()).execute(any(Long.class), eq(adminNumber), any());
-    }
-}
+package com.yd.vibecode.domain.admin.ui;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.yd.vibecode.domain.admin.application.dto.response.AdminListResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.AdminNumberResponse;
+import com.yd.vibecode.domain.admin.application.dto.response.ResetAdminPasswordByMasterResponse;
+import com.yd.vibecode.domain.admin.application.usecase.DeleteAdminByMasterUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.GetAllAdminsUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.IssueAdminNumberUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.ResetAdminPasswordByMasterUseCase;
+import com.yd.vibecode.domain.admin.application.usecase.UpdateAdminNumberUseCase;
+import com.yd.vibecode.global.interceptor.JwtBlacklistInterceptor;
+import com.yd.vibecode.global.security.ExcludeBlacklistPathProperties;
+import com.yd.vibecode.global.security.SecurityConfig;
+import com.yd.vibecode.global.security.TokenProvider;
+
+@WebMvcTest(
+    controllers = AdminNumberController.class,
+    excludeAutoConfiguration = SecurityAutoConfiguration.class,
+    excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+)
+class AdminNumberControllerTest {
+
+    private static final String ACCESS_TOKEN = "access-token";
+    /** JWT @CurrentUser로 전달되는 요청자(MASTER) ID */
+    private static final Long CURRENT_USER_ID = 1L;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private IssueAdminNumberUseCase issueAdminNumberUseCase;
+
+    @MockBean
+    private UpdateAdminNumberUseCase updateAdminNumberUseCase;
+
+    @MockBean
+    private GetAllAdminsUseCase getAllAdminsUseCase;
+
+    @MockBean
+    private ResetAdminPasswordByMasterUseCase resetAdminPasswordByMasterUseCase;
+
+    @MockBean
+    private DeleteAdminByMasterUseCase deleteAdminByMasterUseCase;
+
+    @MockBean
+    private JwtBlacklistInterceptor jwtBlacklistInterceptor;
+
+    @MockBean
+    private ExcludeBlacklistPathProperties excludeBlacklistPathProperties;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        given(jwtBlacklistInterceptor.preHandle(
+                any(HttpServletRequest.class),
+                any(HttpServletResponse.class),
+                any()
+        )).willReturn(true);
+        given(excludeBlacklistPathProperties.getExcludeAuthPaths()).willReturn(Collections.emptyList());
+        given(tokenProvider.getToken(any(HttpServletRequest.class))).willReturn(Optional.of(ACCESS_TOKEN));
+        given(tokenProvider.isAccessToken(ACCESS_TOKEN)).willReturn(true);
+        given(tokenProvider.getId(ACCESS_TOKEN)).willReturn(Optional.of(String.valueOf(CURRENT_USER_ID)));
+    }
+
+    @Test
+    @DisplayName("MASTER - 모든 관리자 조회 성공")
+    @WithMockUser(roles = "MASTER")
+    void master_getAllAdmins_success() throws Exception {
+        AdminListResponse mockResponse = new AdminListResponse(List.of());
+        given(getAllAdminsUseCase.execute(eq(CURRENT_USER_ID))).willReturn(mockResponse);
+
+        mockMvc.perform(get("/api/admin/admin-numbers/admins")
+                .header("Authorization", "Bearer " + ACCESS_TOKEN))
+            .andExpect(status().isOk());
+
+        verify(getAllAdminsUseCase).execute(eq(CURRENT_USER_ID));
+    }
+
+    @Test
+    @DisplayName("MASTER - 관리자 번호 발급 성공")
+    @WithMockUser(roles = "MASTER")
+    void master_issueAdminNumber_success() throws Exception {
+        String requestBody = """
+            {
+                "label": "Test Admin",
+                "expiresAt": "2099-12-31T23:59:59"
+            }
+            """;
+
+        AdminNumberResponse mockResponse = new AdminNumberResponse(
+            "ADM-123456", "Test Admin", true, 1L, null,
+            LocalDateTime.parse("2099-12-31T23:59:59"), null, LocalDateTime.now()
+        );
+
+        given(issueAdminNumberUseCase.execute(eq(CURRENT_USER_ID), any())).willReturn(mockResponse);
+
+        mockMvc.perform(post("/api/admin/admin-numbers")
+                .header("Authorization", "Bearer " + ACCESS_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isOk());
+
+        verify(issueAdminNumberUseCase).execute(eq(CURRENT_USER_ID), any());
+    }
+
+    @Test
+    @DisplayName("MASTER - 관리자 번호 수정 성공")
+    @WithMockUser(roles = "MASTER")
+    void master_updateAdminNumber_success() throws Exception {
+        String adminNumber = "ADM-123456";
+        String requestBody = """
+            {
+                "label": "Updated Admin",
+                "active": false
+            }
+            """;
+
+        AdminNumberResponse mockResponse = new AdminNumberResponse(
+            adminNumber, "Updated Admin", false, 1L, null, null, null, LocalDateTime.now()
+        );
+
+        given(updateAdminNumberUseCase.execute(eq(CURRENT_USER_ID), eq(adminNumber), any()))
+            .willReturn(mockResponse);
+
+        mockMvc.perform(patch("/api/admin/admin-numbers/" + adminNumber)
+                .header("Authorization", "Bearer " + ACCESS_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+            .andExpect(status().isOk());
+
+        verify(updateAdminNumberUseCase).execute(eq(CURRENT_USER_ID), eq(adminNumber), any());
+    }
+
+    @Test
+    @DisplayName("MASTER - 타 관리자 임시 비밀번호 재설정 성공")
+    @WithMockUser(roles = "MASTER")
+    void master_resetAdminPasswordByMaster_success() throws Exception {
+        String adminNumber = "ADM-123456";
+
+        given(resetAdminPasswordByMasterUseCase.execute(eq(CURRENT_USER_ID), eq(adminNumber)))
+                .willReturn(new ResetAdminPasswordByMasterResponse("TempPass1!xYz"));
+
+        mockMvc.perform(patch("/api/admin/admin-numbers/" + adminNumber + "/password/reset")
+                .header("Authorization", "Bearer " + ACCESS_TOKEN))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.result.temporaryPassword").value("TempPass1!xYz"));
+
+        verify(resetAdminPasswordByMasterUseCase).execute(eq(CURRENT_USER_ID), eq(adminNumber));
+        verify(updateAdminNumberUseCase, never()).execute(any(Long.class), eq(adminNumber), any());
+    }
+
+    @Test
+    @DisplayName("MASTER - 관리자 계정 삭제 성공")
+    @WithMockUser(roles = "MASTER")
+    void master_deleteAdminByMaster_success() throws Exception {
+        String adminNumber = "ADM-123456";
+
+        mockMvc.perform(delete("/api/admin/admin-numbers/" + adminNumber)
+                .header("Authorization", "Bearer " + ACCESS_TOKEN))
+            .andExpect(status().isOk());
+
+        verify(deleteAdminByMasterUseCase).execute(eq(CURRENT_USER_ID), eq(adminNumber));
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminAccessAuthValidatorTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminAccessAuthValidatorTest.java
@@ -1,0 +1,88 @@
+package com.yd.vibecode.domain.auth.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.repository.AdminRepository;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAccessAuthValidatorTest {
+
+    @InjectMocks
+    private AdminAccessAuthValidator adminAccessAuthValidator;
+
+    @Mock
+    private AdminRepository adminRepository;
+
+    @Test
+    @DisplayName("삭제된 관리자는 access token 인증에서 차단된다")
+    void validateActiveForAuthentication_deletedAdmin_throws() {
+        Admin admin = Admin.builder()
+                .adminNumber("admin123")
+                .email("admin@example.com")
+                .passwordHash("encoded")
+                .isActive(false)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 1L);
+        admin.delete();
+
+        given(adminRepository.findById(1L)).willReturn(Optional.of(admin));
+
+        RestApiException exception = assertThrows(
+                RestApiException.class,
+                () -> adminAccessAuthValidator.validateActiveForAuthentication(1L));
+
+        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE.getCode());
+    }
+
+    @Test
+    @DisplayName("비활성 관리자는 access token 인증에서 차단된다")
+    void validateActiveForAuthentication_inactiveAdmin_throws() {
+        Admin admin = Admin.builder()
+                .adminNumber("admin123")
+                .email("admin@example.com")
+                .passwordHash("encoded")
+                .isActive(false)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 2L);
+
+        given(adminRepository.findById(2L)).willReturn(Optional.of(admin));
+
+        RestApiException exception = assertThrows(
+                RestApiException.class,
+                () -> adminAccessAuthValidator.validateActiveForAuthentication(2L));
+
+        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE.getCode());
+    }
+
+    @Test
+    @DisplayName("활성 관리자는 access token 인증 검증을 통과한다")
+    void validateActiveForAuthentication_activeAdmin_passes() {
+        Admin admin = Admin.builder()
+                .adminNumber("admin123")
+                .email("admin@example.com")
+                .passwordHash("encoded")
+                .isActive(true)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 3L);
+
+        given(adminRepository.findById(3L)).willReturn(Optional.of(admin));
+
+        assertDoesNotThrow(() -> adminAccessAuthValidator.validateActiveForAuthentication(3L));
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminAccountDeletionServiceTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminAccountDeletionServiceTest.java
@@ -1,0 +1,169 @@
+package com.yd.vibecode.domain.auth.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.yd.vibecode.domain.admin.domain.service.AdminAuditLogService;
+import com.yd.vibecode.domain.auth.domain.entity.Admin;
+import com.yd.vibecode.domain.auth.domain.entity.AdminNumber;
+import com.yd.vibecode.domain.auth.domain.entity.AdminRole;
+import com.yd.vibecode.domain.auth.domain.repository.AdminNumberRepository;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+import com.yd.vibecode.global.exception.code.status.GlobalErrorStatus;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAccountDeletionServiceTest {
+
+    private static final String ADMIN_NUMBER = "ADM-000001";
+    private static final Long TARGET_ADMIN_ID = 10L;
+    private static final Long ACTOR_ADMIN_ID = 1L;
+    private static final String AUDIT_ACTION = "DELETE_ADMIN_BY_MASTER";
+
+    @InjectMocks
+    private AdminAccountDeletionService adminAccountDeletionService;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private AdminNumberRepository adminNumberRepository;
+
+    @Mock
+    private AdminAuditLogService adminAuditLogService;
+
+    @Test
+    @DisplayName("softDelete는 관리자 삭제의 모든 side effect를 한 번에 수행한다")
+    void softDelete_appliesAllSideEffects() {
+        Admin admin = activeAdmin();
+        AdminNumber adminNumber = linkedAdminNumber();
+
+        given(adminNumberRepository.findByAdminNumber(ADMIN_NUMBER)).willReturn(Optional.of(adminNumber));
+
+        adminAccountDeletionService.softDelete(admin, ACTOR_ADMIN_ID, AUDIT_ACTION);
+
+        assertThat(admin.isDeleted()).isTrue();
+        assertThat(admin.getDeletedAt()).isNotNull();
+        assertThat(admin.getIsActive()).isFalse();
+
+        verify(refreshTokenService).deleteRefreshToken(eq(TARGET_ADMIN_ID.toString()));
+        verify(adminNumberRepository).findByAdminNumber(ADMIN_NUMBER);
+        assertThat(adminNumber.getIsActive()).isFalse();
+
+        ArgumentCaptor<Map<String, Object>> auditPayloadCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(adminAuditLogService).log(eq(ACTOR_ADMIN_ID), eq(AUDIT_ACTION), auditPayloadCaptor.capture());
+        Map<String, Object> auditPayload = auditPayloadCaptor.getValue();
+        assertThat(auditPayload)
+                .containsEntry("targetAdminId", TARGET_ADMIN_ID)
+                .containsEntry("targetAdminNumber", ADMIN_NUMBER);
+    }
+
+    @Test
+    @DisplayName("연결된 admin number가 없어도 관리자 soft delete side effect는 수행된다")
+    void softDelete_withoutLinkedAdminNumber_stillSoftDeletesAdmin() {
+        Admin admin = activeAdmin();
+
+        given(adminNumberRepository.findByAdminNumber(ADMIN_NUMBER)).willReturn(Optional.empty());
+
+        adminAccountDeletionService.softDelete(admin, ACTOR_ADMIN_ID, AUDIT_ACTION);
+
+        assertThat(admin.isDeleted()).isTrue();
+        assertThat(admin.getIsActive()).isFalse();
+        verify(refreshTokenService).deleteRefreshToken(eq(TARGET_ADMIN_ID.toString()));
+        verify(adminAuditLogService).log(eq(ACTOR_ADMIN_ID), eq(AUDIT_ACTION), org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("actorAdminId 또는 auditAction이 null이면 audit log는 기록하지 않는다")
+    void softDelete_withoutActorOrAction_skipsAuditLog() {
+        Admin admin = activeAdmin();
+
+        given(adminNumberRepository.findByAdminNumber(ADMIN_NUMBER)).willReturn(Optional.empty());
+
+        adminAccountDeletionService.softDelete(admin, null, AUDIT_ACTION);
+        adminAccountDeletionService.softDelete(activeAdmin(), ACTOR_ADMIN_ID, null);
+
+        verify(adminAuditLogService, never()).log(
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyString(),
+                org.mockito.ArgumentMatchers.any()
+        );
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 관리자는 soft delete할 수 없다")
+    void softDelete_alreadyDeleted_throwsNotFound() {
+        Admin admin = activeAdmin();
+        admin.delete();
+
+        assertThatThrownBy(() -> adminAccountDeletionService.softDelete(admin, ACTOR_ADMIN_ID, AUDIT_ACTION))
+                .isInstanceOf(RestApiException.class)
+                .extracting(ex -> ((RestApiException) ex).getErrorCode())
+                .isEqualTo(GlobalErrorStatus._NOT_FOUND.getCode());
+
+        verify(refreshTokenService, never()).deleteRefreshToken(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    @DisplayName("MASTER 계정은 soft delete할 수 없다")
+    void softDelete_masterAccount_throws() {
+        Admin master = Admin.builder()
+                .adminNumber("MASTER-001")
+                .email("master@example.com")
+                .passwordHash("hash")
+                .role(AdminRole.MASTER)
+                .isActive(true)
+                .build();
+        ReflectionTestUtils.setField(master, "id", 99L);
+
+        assertThatThrownBy(() -> adminAccountDeletionService.softDelete(master, ACTOR_ADMIN_ID, AUDIT_ACTION))
+                .isInstanceOf(RestApiException.class)
+                .extracting(ex -> ((RestApiException) ex).getErrorCode())
+                .isEqualTo(AuthErrorStatus.MASTER_ACCOUNT_CANNOT_BE_DEACTIVATED.getCode());
+
+        assertThat(master.isDeleted()).isFalse();
+        assertThat(master.getIsActive()).isTrue();
+        verify(refreshTokenService, never()).deleteRefreshToken(org.mockito.ArgumentMatchers.anyString());
+    }
+
+    private Admin activeAdmin() {
+        Admin admin = Admin.builder()
+                .adminNumber(ADMIN_NUMBER)
+                .email("target@example.com")
+                .passwordHash("hash")
+                .role(AdminRole.ADMIN)
+                .isActive(true)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", TARGET_ADMIN_ID);
+        return admin;
+    }
+
+    private AdminNumber linkedAdminNumber() {
+        return AdminNumber.builder()
+                .adminNumber(ADMIN_NUMBER)
+                .label("Test Admin")
+                .isActive(true)
+                .issuedBy(ACTOR_ADMIN_ID)
+                .assignedAdminId(TARGET_ADMIN_ID)
+                .usedAt(LocalDateTime.now())
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
+    }
+}

--- a/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminServiceTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminServiceTest.java
@@ -20,8 +20,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.test.util.ReflectionTestUtils;
-
 @ExtendWith(MockitoExtension.class)
 class AdminServiceTest {
 
@@ -81,63 +79,6 @@ class AdminServiceTest {
 
         assertThat(admin.getLastLoginAt()).isNotNull();
         verify(adminRepository, never()).save(any(Admin.class));
-    }
-
-    @Test
-    @DisplayName("삭제된 관리자는 access token 인증에서 차단된다")
-    void validateActiveForAuthentication_deletedAdmin_throws() {
-        Admin admin = Admin.builder()
-                .adminNumber("admin123")
-                .email("admin@example.com")
-                .passwordHash("encoded")
-                .isActive(false)
-                .build();
-        ReflectionTestUtils.setField(admin, "id", 1L);
-        admin.delete();
-
-        given(adminRepository.findById(1L)).willReturn(Optional.of(admin));
-
-        RestApiException exception = assertThrows(
-                RestApiException.class,
-                () -> adminService.validateActiveForAuthentication(1L));
-
-        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE.getCode());
-    }
-
-    @Test
-    @DisplayName("비활성 관리자는 access token 인증에서 차단된다")
-    void validateActiveForAuthentication_inactiveAdmin_throws() {
-        Admin admin = Admin.builder()
-                .adminNumber("admin123")
-                .email("admin@example.com")
-                .passwordHash("encoded")
-                .isActive(false)
-                .build();
-        ReflectionTestUtils.setField(admin, "id", 2L);
-
-        given(adminRepository.findById(2L)).willReturn(Optional.of(admin));
-
-        RestApiException exception = assertThrows(
-                RestApiException.class,
-                () -> adminService.validateActiveForAuthentication(2L));
-
-        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE.getCode());
-    }
-
-    @Test
-    @DisplayName("활성 관리자는 access token 인증 검증을 통과한다")
-    void validateActiveForAuthentication_activeAdmin_passes() {
-        Admin admin = Admin.builder()
-                .adminNumber("admin123")
-                .email("admin@example.com")
-                .passwordHash("encoded")
-                .isActive(true)
-                .build();
-        ReflectionTestUtils.setField(admin, "id", 3L);
-
-        given(adminRepository.findById(3L)).willReturn(Optional.of(admin));
-
-        assertDoesNotThrow(() -> adminService.validateActiveForAuthentication(3L));
     }
 
     @Test

--- a/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminServiceTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/domain/service/AdminServiceTest.java
@@ -20,6 +20,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class AdminServiceTest {
@@ -80,6 +81,63 @@ class AdminServiceTest {
 
         assertThat(admin.getLastLoginAt()).isNotNull();
         verify(adminRepository, never()).save(any(Admin.class));
+    }
+
+    @Test
+    @DisplayName("삭제된 관리자는 access token 인증에서 차단된다")
+    void validateActiveForAuthentication_deletedAdmin_throws() {
+        Admin admin = Admin.builder()
+                .adminNumber("admin123")
+                .email("admin@example.com")
+                .passwordHash("encoded")
+                .isActive(false)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 1L);
+        admin.delete();
+
+        given(adminRepository.findById(1L)).willReturn(Optional.of(admin));
+
+        RestApiException exception = assertThrows(
+                RestApiException.class,
+                () -> adminService.validateActiveForAuthentication(1L));
+
+        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE.getCode());
+    }
+
+    @Test
+    @DisplayName("비활성 관리자는 access token 인증에서 차단된다")
+    void validateActiveForAuthentication_inactiveAdmin_throws() {
+        Admin admin = Admin.builder()
+                .adminNumber("admin123")
+                .email("admin@example.com")
+                .passwordHash("encoded")
+                .isActive(false)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 2L);
+
+        given(adminRepository.findById(2L)).willReturn(Optional.of(admin));
+
+        RestApiException exception = assertThrows(
+                RestApiException.class,
+                () -> adminService.validateActiveForAuthentication(2L));
+
+        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE.getCode());
+    }
+
+    @Test
+    @DisplayName("활성 관리자는 access token 인증 검증을 통과한다")
+    void validateActiveForAuthentication_activeAdmin_passes() {
+        Admin admin = Admin.builder()
+                .adminNumber("admin123")
+                .email("admin@example.com")
+                .passwordHash("encoded")
+                .isActive(true)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 3L);
+
+        given(adminRepository.findById(3L)).willReturn(Optional.of(admin));
+
+        assertDoesNotThrow(() -> adminService.validateActiveForAuthentication(3L));
     }
 
     @Test

--- a/src/test/java/com/yd/vibecode/domain/auth/ui/AuthControllerTest.java
+++ b/src/test/java/com/yd/vibecode/domain/auth/ui/AuthControllerTest.java
@@ -198,6 +198,33 @@ class AuthControllerTest {
         verify(cookieUtils).setRefreshTokenCookie(any(HttpServletResponse.class), eq("new-refresh"), eq(120));
     }
 
+    @Test
+    @DisplayName("관리자 토큰 재발급 API — refresh token 없으면 400 AUTH007 및 쿠키 삭제")
+    void admin_reissue_api_missing_refresh_token_clears_cookies() throws Exception {
+        given(cookieUtils.getRefreshTokenFromRequest(any(HttpServletRequest.class))).willReturn(null);
+
+        mockMvc.perform(post("/api/auth/admin/reissue"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("AUTH007"));
+
+        verify(cookieUtils).clearAccessTokenCookie(any(HttpServletResponse.class));
+        verify(cookieUtils).clearRefreshTokenCookie(any(HttpServletResponse.class));
+    }
+
+    @Test
+    @DisplayName("관리자 토큰 재발급 API — refresh token 만료 시 400 AUTH005 및 쿠키 삭제")
+    void admin_reissue_api_expired_refresh_token_clears_cookies() throws Exception {
+        given(cookieUtils.getRefreshTokenFromRequest(any(HttpServletRequest.class))).willReturn("expired-refresh");
+        given(tokenProvider.validateToken("expired-refresh")).willReturn(false);
+
+        mockMvc.perform(post("/api/auth/admin/reissue"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("AUTH005"));
+
+        verify(cookieUtils).clearAccessTokenCookie(any(HttpServletResponse.class));
+        verify(cookieUtils).clearRefreshTokenCookie(any(HttpServletResponse.class));
+    }
+
     // =========================================================================
     // 3. POST /api/auth/admin/logout — 관리자 로그아웃
     // =========================================================================

--- a/src/test/java/com/yd/vibecode/global/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/yd/vibecode/global/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,148 @@
+package com.yd.vibecode.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.domain.auth.domain.service.RefreshTokenService;
+import com.yd.vibecode.domain.auth.domain.service.TokenWhitelistService;
+import com.yd.vibecode.global.exception.RestApiException;
+import com.yd.vibecode.global.exception.code.status.AuthErrorStatus;
+
+import jakarta.servlet.FilterChain;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+  @Mock private TokenProvider tokenProvider;
+  @Mock private ExcludeAuthPathProperties excludeAuthPathProperties;
+  @Mock private RefreshTokenService refreshTokenService;
+  @Mock private TokenWhitelistService tokenWhitelistService;
+  @Mock private AdminService adminService;
+  @Mock private FilterChain filterChain;
+
+  private JwtAuthenticationFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    filter =
+        new JwtAuthenticationFilter(
+            tokenProvider,
+            excludeAuthPathProperties,
+            refreshTokenService,
+            tokenWhitelistService,
+            adminService);
+    SecurityContextHolder.clearContext();
+    given(excludeAuthPathProperties.getPaths()).willReturn(Collections.emptyList());
+  }
+
+  @Test
+  @DisplayName("삭제된 관리자 access token으로 보호 API 접근 시 401")
+  void deletedAdminAccessToken_returnsUnauthorized() throws Exception {
+    String token = "deleted-admin-token";
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/admin/admin-numbers/admins");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    given(tokenProvider.getToken(request)).willReturn(Optional.of(token));
+    given(tokenWhitelistService.isWhitelistToken(token)).willReturn(false);
+    given(tokenProvider.validateToken(token)).willReturn(true);
+    given(tokenProvider.getRole(token)).willReturn(Optional.of("ADMIN"));
+    given(tokenProvider.getId(token)).willReturn(Optional.of("42"));
+    willThrow(new RestApiException(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE))
+        .given(adminService)
+        .validateActiveForAuthentication(42L);
+
+    filter.doFilter(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(401);
+    verify(filterChain, never()).doFilter(any(), any());
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+  }
+
+  @Test
+  @DisplayName("활성 관리자 access token은 인증 성공")
+  void activeAdminAccessToken_authenticates() throws Exception {
+    String token = "active-admin-token";
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/admin/admin-numbers/admins");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    given(tokenProvider.getToken(request)).willReturn(Optional.of(token));
+    given(tokenWhitelistService.isWhitelistToken(token)).willReturn(false);
+    given(tokenProvider.validateToken(token)).willReturn(true);
+    given(tokenProvider.getRole(token)).willReturn(Optional.of("ADMIN"));
+    given(tokenProvider.getId(token)).willReturn(Optional.of("1"));
+    given(tokenProvider.getAuthentication(token))
+        .willReturn(
+            new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                "1", "", List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_ADMIN"))));
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(adminService).validateActiveForAuthentication(1L);
+    verify(filterChain).doFilter(request, response);
+    assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("USER role access token은 관리자 활성 검증을 하지 않는다")
+  void userAccessToken_skipsAdminValidation() throws Exception {
+    String token = "user-token";
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/exams/1/session");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    given(tokenProvider.getToken(request)).willReturn(Optional.of(token));
+    given(tokenWhitelistService.isWhitelistToken(token)).willReturn(false);
+    given(tokenProvider.validateToken(token)).willReturn(true);
+    given(tokenProvider.getRole(token)).willReturn(Optional.of("USER"));
+    given(tokenProvider.getAuthentication(token))
+        .willReturn(
+            new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+                "10", "", List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority("ROLE_USER"))));
+
+    filter.doFilter(request, response, filterChain);
+
+    verify(adminService, never()).validateActiveForAuthentication(any());
+    verify(filterChain).doFilter(request, response);
+  }
+
+  @Test
+  @DisplayName("whitelist 캐시된 관리자 토큰도 활성 검증을 수행한다")
+  void whitelistedDeletedAdminToken_returnsUnauthorized() throws Exception {
+    String token = "whitelisted-deleted-admin-token";
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/admin/exams");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    given(tokenProvider.getToken(request)).willReturn(Optional.of(token));
+    given(tokenWhitelistService.isWhitelistToken(token)).willReturn(true);
+    given(tokenProvider.getRole(token)).willReturn(Optional.of("MASTER"));
+    given(tokenProvider.getId(token)).willReturn(Optional.of("99"));
+    willThrow(new RestApiException(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE))
+        .given(adminService)
+        .validateActiveForAuthentication(99L);
+
+    filter.doFilter(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(401);
+    verify(adminService).validateActiveForAuthentication(eq(99L));
+    verify(filterChain, never()).doFilter(any(), any());
+  }
+}

--- a/src/test/java/com/yd/vibecode/global/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/yd/vibecode/global/security/JwtAuthenticationFilterTest.java
@@ -22,7 +22,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import com.yd.vibecode.domain.auth.domain.service.AdminService;
+import com.yd.vibecode.domain.auth.domain.service.AdminAccessAuthValidator;
 import com.yd.vibecode.domain.auth.domain.service.RefreshTokenService;
 import com.yd.vibecode.domain.auth.domain.service.TokenWhitelistService;
 import com.yd.vibecode.global.exception.RestApiException;
@@ -37,7 +37,7 @@ class JwtAuthenticationFilterTest {
   @Mock private ExcludeAuthPathProperties excludeAuthPathProperties;
   @Mock private RefreshTokenService refreshTokenService;
   @Mock private TokenWhitelistService tokenWhitelistService;
-  @Mock private AdminService adminService;
+  @Mock private AdminAccessAuthValidator adminAccessAuthValidator;
   @Mock private FilterChain filterChain;
 
   private JwtAuthenticationFilter filter;
@@ -50,7 +50,7 @@ class JwtAuthenticationFilterTest {
             excludeAuthPathProperties,
             refreshTokenService,
             tokenWhitelistService,
-            adminService);
+            adminAccessAuthValidator);
     SecurityContextHolder.clearContext();
     given(excludeAuthPathProperties.getPaths()).willReturn(Collections.emptyList());
   }
@@ -68,7 +68,7 @@ class JwtAuthenticationFilterTest {
     given(tokenProvider.getRole(token)).willReturn(Optional.of("ADMIN"));
     given(tokenProvider.getId(token)).willReturn(Optional.of("42"));
     willThrow(new RestApiException(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE))
-        .given(adminService)
+        .given(adminAccessAuthValidator)
         .validateActiveForAuthentication(42L);
 
     filter.doFilter(request, response, filterChain);
@@ -97,7 +97,7 @@ class JwtAuthenticationFilterTest {
 
     filter.doFilter(request, response, filterChain);
 
-    verify(adminService).validateActiveForAuthentication(1L);
+    verify(adminAccessAuthValidator).validateActiveForAuthentication(1L);
     verify(filterChain).doFilter(request, response);
     assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
   }
@@ -120,7 +120,7 @@ class JwtAuthenticationFilterTest {
 
     filter.doFilter(request, response, filterChain);
 
-    verify(adminService, never()).validateActiveForAuthentication(any());
+    verify(adminAccessAuthValidator, never()).validateActiveForAuthentication(any());
     verify(filterChain).doFilter(request, response);
   }
 
@@ -136,13 +136,13 @@ class JwtAuthenticationFilterTest {
     given(tokenProvider.getRole(token)).willReturn(Optional.of("MASTER"));
     given(tokenProvider.getId(token)).willReturn(Optional.of("99"));
     willThrow(new RestApiException(AuthErrorStatus.ADMIN_ACCOUNT_INACTIVE))
-        .given(adminService)
+        .given(adminAccessAuthValidator)
         .validateActiveForAuthentication(99L);
 
     filter.doFilter(request, response, filterChain);
 
     assertThat(response.getStatus()).isEqualTo(401);
-    verify(adminService).validateActiveForAuthentication(eq(99L));
+    verify(adminAccessAuthValidator).validateActiveForAuthentication(eq(99L));
     verify(filterChain, never()).doFilter(any(), any());
   }
 }


### PR DESCRIPTION
BE QA 수정사항이 develop에 merge된 뒤, 로컬에서 develop 기준으로 주요 수정사항 재확인했습니다.

확인한 내용:
- POST /api/auth/admin/reissue 실패 시 HTTP 400 및 body.code 확인
- reissue 실패 응답에서 access_token/refresh_token Clear-Cookie 헤더 확인
- MASTER가 일반 관리자 계정 삭제 시 삭제 API 정상 동작 확인
- 삭제된 관리자 계정의 기존 access_token으로 보호 API 호출 시 HTTP 401 및 “비활성화된 관리자 계정입니다.” 응답 확인
- 일반 ADMIN 본인 계정 삭제 후에도 기존 access_token으로 보호 API 호출 시 HTTP 401 및 “비활성화된 관리자 계정입니다.” 응답 확인
- develop 최신 기준 ./gradlew test BUILD SUCCESSFUL 확인

현재 확인한 BE 범위에서는 문제 없어 보여서 develop → main PR 진행해도 될 것 같습니다.